### PR TITLE
feat: send reports to organisation email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,5 +35,6 @@ RATE_LIMIT=
 # TRUE | number | string (https://expressjs.com/en/guide/behind-proxies.html) use BACKEND_URL/ip to validate
 TRUST_PROXY=
 
+# ⚠️Deprecated⚠️ Use send via mail under connection settings
 # If set to 'TRUE', all reports will be saved to `/reports` in the backend container. Uncomment the corresponding backend volume in `docker-compose.yml` to get reports on host maschine
 BACKEND_SAVE_REPORTS_ON_DISK=FALSE

--- a/backend/authStrategies/magiclogin.ts
+++ b/backend/authStrategies/magiclogin.ts
@@ -21,7 +21,7 @@ export default new MagicLoginStrategy.default({
         i18n.t('mail.magiclogin.subject', { lng: user.settings.language }),
         i18n.t('mail.magiclogin.paragraph', { lng: user.settings.language }),
         { text: i18n.t('mail.magiclogin.buttonText', { lng: user.settings.language }), link: href },
-        '',
+        undefined,
         false
       )
     } else {

--- a/backend/controller/expenseReportController.ts
+++ b/backend/controller/expenseReportController.ts
@@ -8,7 +8,7 @@ import { sendNotificationMail } from '../mail/mail.js'
 import ExpenseReport, { ExpenseReportDoc } from '../models/expenseReport.js'
 import User from '../models/user.js'
 import { generateExpenseReportReport } from '../pdf/expenseReport.js'
-import { writeToDiskFilePath } from '../pdf/helper.js'
+import { sendViaMail, writeToDiskFilePath } from '../pdf/helper.js'
 import { Controller, GetterQuery, SetterBody } from './controller.js'
 import { AuthorizationError, NotFoundError } from './error.js'
 import { IdDocument, MoneyPost } from './types.js'
@@ -273,6 +273,7 @@ export class ExpenseReportExamineController extends Controller {
 
     const cb = async (expenseReport: IExpenseReport) => {
       sendNotificationMail(expenseReport)
+      sendViaMail(expenseReport)
       if (process.env.BACKEND_SAVE_REPORTS_ON_DISK.toLowerCase() === 'true') {
         await writeToDisk(
           await writeToDiskFilePath(expenseReport),

--- a/backend/controller/healthCareCostController.ts
+++ b/backend/controller/healthCareCostController.ts
@@ -16,7 +16,7 @@ import HealthCareCost, { HealthCareCostDoc } from '../models/healthCareCost.js'
 import Organisation from '../models/organisation.js'
 import User from '../models/user.js'
 import { generateHealthCareCostReport } from '../pdf/healthCareCost.js'
-import { writeToDiskFilePath } from '../pdf/helper.js'
+import { sendViaMail, writeToDiskFilePath } from '../pdf/helper.js'
 import { Controller, GetterQuery, SetterBody } from './controller.js'
 import { AuthorizationError, NotAllowedError } from './error.js'
 import { IdDocument, MoneyPlusPost } from './types.js'
@@ -251,6 +251,7 @@ export class HealthCareCostExamineController extends Controller {
 
     const cb = async (healthCareCost: IHealthCareCost) => {
       sendNotificationMail(healthCareCost)
+      sendViaMail(healthCareCost)
       if (process.env.BACKEND_SAVE_REPORTS_ON_DISK.toLowerCase() === 'true') {
         await writeToDisk(
           await writeToDiskFilePath(healthCareCost),
@@ -371,6 +372,7 @@ export class HealthCareCostConfirmController extends Controller {
 
     const cb = async (healthCareCost: IHealthCareCost) => {
       sendNotificationMail(healthCareCost)
+      sendViaMail(healthCareCost)
       if (process.env.BACKEND_SAVE_REPORTS_ON_DISK.toLowerCase() === 'true') {
         await writeToDisk(
           await writeToDiskFilePath(healthCareCost),

--- a/backend/controller/travelController.ts
+++ b/backend/controller/travelController.ts
@@ -8,7 +8,7 @@ import { sendNotificationMail } from '../mail/mail.js'
 import Travel, { TravelDoc } from '../models/travel.js'
 import User from '../models/user.js'
 import { generateAdvanceReport } from '../pdf/advance.js'
-import { writeToDiskFilePath } from '../pdf/helper.js'
+import { sendViaMail, writeToDiskFilePath } from '../pdf/helper.js'
 import { generateTravelReport } from '../pdf/travel.js'
 import { Controller, GetterQuery, SetterBody } from './controller.js'
 import { AuthorizationError, NotAllowedError } from './error.js'
@@ -278,12 +278,11 @@ export class TravelApproveController extends Controller {
     }
     const cb = async (travel: ITravel) => {
       sendNotificationMail(travel)
-      if (
-        travel.advance.amount !== null &&
-        travel.advance.amount > 0 &&
-        process.env.BACKEND_SAVE_REPORTS_ON_DISK.toLowerCase() === 'true'
-      ) {
-        await writeToDisk(await writeToDiskFilePath(travel), await generateAdvanceReport(travel, i18n.language as Locale))
+      if (travel.advance.amount !== null && travel.advance.amount > 0) {
+        sendViaMail(travel)
+        if (process.env.BACKEND_SAVE_REPORTS_ON_DISK.toLowerCase() === 'true') {
+          await writeToDisk(await writeToDiskFilePath(travel), await generateAdvanceReport(travel, i18n.language as Locale))
+        }
       }
     }
 
@@ -448,6 +447,7 @@ export class TravelExamineController extends Controller {
 
     const cb = async (travel: ITravel) => {
       sendNotificationMail(travel)
+      sendViaMail(travel)
       if (process.env.BACKEND_SAVE_REPORTS_ON_DISK.toLowerCase() === 'true') {
         await writeToDisk(await writeToDiskFilePath(travel), await generateTravelReport(travel, i18n.language as Locale))
       }

--- a/backend/controller/uploadController.ts
+++ b/backend/controller/uploadController.ts
@@ -1,6 +1,5 @@
 import ejs from 'ejs'
 import { Request as ExRequest, Response as ExResponse, NextFunction } from 'express'
-import fs from 'fs/promises'
 import { Body, Consumes, Controller, Get, Middlewares, Post, Produces, Query, Request, Route, SuccessResponse } from 'tsoa'
 import { _id } from '../../common/types.js'
 import { getSettings } from '../db.js'
@@ -8,6 +7,7 @@ import { documentFileHandler, fileHandler } from '../helper.js'
 import i18n from '../i18n.js'
 import Token from '../models/token.js'
 import User from '../models/user.js'
+import { getUploadTemplate } from '../templates/cache.js'
 import { AuthorizationError, NotFoundError } from './error.js'
 import { File } from './types.js'
 
@@ -33,7 +33,7 @@ export class UploadController extends Controller {
   ): Promise<void> {
     const settings = await getSettings()
     const user = await User.findOne({ _id: userId }).lean()
-    const template = await fs.readFile('./templates/upload.ejs', { encoding: 'utf-8' })
+    const template = await getUploadTemplate()
     const url = new URL(process.env.VITE_BACKEND_URL + '/upload/new')
     url.searchParams.append('userId', userId)
     url.searchParams.append('tokenId', tokenId)

--- a/backend/controller/uploadController.ts
+++ b/backend/controller/uploadController.ts
@@ -1,6 +1,6 @@
 import ejs from 'ejs'
 import { Request as ExRequest, Response as ExResponse, NextFunction } from 'express'
-import fs from 'node:fs/promises'
+import fs from 'fs/promises'
 import { Body, Consumes, Controller, Get, Middlewares, Post, Produces, Query, Request, Route, SuccessResponse } from 'tsoa'
 import { _id } from '../../common/types.js'
 import { getSettings } from '../db.js'

--- a/backend/data/connectionSettings.development.json
+++ b/backend/data/connectionSettings.development.json
@@ -22,5 +22,9 @@
         "user": "username",
         "password": "password",
         "senderAddress": "info@abrechnung.com"
+    },
+    "PDFReportsViaEmail": {
+        "sendPDFReportsToOrganisationEmail": false,
+        "locale": "de"
     }
 }

--- a/backend/db.ts
+++ b/backend/db.ts
@@ -56,12 +56,12 @@ export async function initDB() {
   }
 
   if (process.env.NODE_ENV === 'development') {
-    await initer(ConnectionSettings, 'connectionSettings', [connectionSettingsDevelopment], true)
+    await initer(ConnectionSettings, 'connectionSettings', [connectionSettingsDevelopment as Partial<IConnectionSettings>], true)
   } else {
-    const emtpyConnectionSettings: Partial<IConnectionSettings> = {
+    const emptyConnectionSettings: Partial<IConnectionSettings> = {
       auth: {}
     }
-    await initer(ConnectionSettings, 'connectionSettings', [emtpyConnectionSettings])
+    await initer(ConnectionSettings, 'connectionSettings', [emptyConnectionSettings])
   }
 
   await initer(DisplaySettings, 'displaySettings', [displaySettings as Partial<IDisplaySettings>])

--- a/backend/db.ts
+++ b/backend/db.ts
@@ -58,10 +58,7 @@ export async function initDB() {
   if (process.env.NODE_ENV === 'development') {
     await initer(ConnectionSettings, 'connectionSettings', [connectionSettingsDevelopment as Partial<IConnectionSettings>], true)
   } else {
-    const emptyConnectionSettings: Partial<IConnectionSettings> = {
-      auth: {}
-    }
-    await initer(ConnectionSettings, 'connectionSettings', [emptyConnectionSettings])
+    await initer(ConnectionSettings, 'connectionSettings', [{} as Partial<IConnectionSettings>])
   }
 
   await initer(DisplaySettings, 'displaySettings', [displaySettings as Partial<IDisplaySettings>])

--- a/backend/mail/mail.ts
+++ b/backend/mail/mail.ts
@@ -1,5 +1,5 @@
 import ejs from 'ejs'
-import fs from 'fs'
+import fs from 'fs/promises'
 import nodemailer from 'nodemailer'
 import {
   ExpenseReportSimple,
@@ -66,7 +66,7 @@ async function _sendMail(
     url: process.env.VITE_FRONTEND_URL
   }
 
-  const template = fs.readFileSync('./templates/mail.ejs', { encoding: 'utf-8' })
+  const template = await fs.readFile('./templates/mail.ejs', { encoding: 'utf-8' })
   const renderedHTML = ejs.render(template, {
     salutation,
     paragraph,

--- a/backend/mail/mail.ts
+++ b/backend/mail/mail.ts
@@ -17,7 +17,7 @@ import i18n, { formatter } from '../i18n.js'
 import User from '../models/user.js'
 import { mapSmtpConfig } from '../settingsValidator.js'
 
-async function getClient() {
+export async function getClient() {
   const connectionSettings = await getConnectionSettings()
   if (connectionSettings.smtp?.host) {
     return nodemailer.createTransport(mapSmtpConfig(connectionSettings.smtp))

--- a/backend/mail/mail.ts
+++ b/backend/mail/mail.ts
@@ -34,6 +34,7 @@ export async function sendMail(
   lastParagraph?: string,
   authenticateLink = true
 ) {
+  const mailPromises = []
   for (let i = 0; i < recipients.length; i++) {
     const language = recipients[i].settings.language
     let recipientButton: { text: string; link: string } | undefined = undefined
@@ -46,8 +47,9 @@ export async function sendMail(
         })
       }
     }
-    _sendMail(recipients[i], subject, paragraph, language, recipientButton, lastParagraph)
+    mailPromises.push(_sendMail(recipients[i], subject, paragraph, language, recipientButton, lastParagraph))
   }
+  return await Promise.allSettled(mailPromises)
 }
 
 async function _sendMail(
@@ -89,7 +91,7 @@ async function _sendMail(
     ': ' +
     app.url
 
-  mailClient.sendMail({
+  return await mailClient.sendMail({
     from: '"' + app.name + '" <' + mailClient.options.from + '>', // sender address
     to: recipient.email, // list of receivers
     subject: subject, // Subject line

--- a/backend/mail/mail.ts
+++ b/backend/mail/mail.ts
@@ -1,5 +1,4 @@
 import ejs from 'ejs'
-import fs from 'fs/promises'
 import nodemailer from 'nodemailer'
 import {
   ExpenseReportSimple,
@@ -16,6 +15,7 @@ import { genAuthenticatedLink } from '../helper.js'
 import i18n, { formatter } from '../i18n.js'
 import User from '../models/user.js'
 import { mapSmtpConfig } from '../settingsValidator.js'
+import { getMailTemplate } from '../templates/cache.js'
 
 export async function getClient() {
   const connectionSettings = await getConnectionSettings()
@@ -68,7 +68,7 @@ async function _sendMail(
     url: process.env.VITE_FRONTEND_URL
   }
 
-  const template = await fs.readFile('./templates/mail.ejs', { encoding: 'utf-8' })
+  const template = await getMailTemplate()
   const renderedHTML = ejs.render(template, {
     salutation,
     paragraph,

--- a/backend/migrations.ts
+++ b/backend/migrations.ts
@@ -124,6 +124,16 @@ export async function checkForMigrations() {
       }
       await mongoose.connection.collection('displaysettings').updateOne({}, { $set: displaySettingsFromEnv })
     }
+    if (semver.lte(migrateFrom, '1.4.1')) {
+      console.log('Apply migration from v1.4.1: Add PDFReportsViaEmail Settings')
+      const displaySettings = await mongoose.connection.collection('displaysettings').findOne({})
+      await mongoose.connection
+        .collection('connectionsettings')
+        .updateOne(
+          {},
+          { $set: { PDFReportsViaEmail: { sendPDFReportsToOrganisationEmail: false, locale: displaySettings?.locale?.default || 'de' } } }
+        )
+    }
     if (settings) {
       settings.migrateFrom = undefined
       await settings.save()

--- a/backend/models/connectionSettings.ts
+++ b/backend/models/connectionSettings.ts
@@ -1,13 +1,20 @@
 import { HydratedDocument, model, Schema } from 'mongoose'
-import { ConnectionSettings, emailRegex } from '../../common/types.js'
+import { ConnectionSettings, emailRegex, locales } from '../../common/types.js'
 import { verifyLdapauthConfig, verifySmtpConfig } from '../settingsValidator.js'
 
 function requiredIf(ifPath: string) {
-  return [{ required: [ifPath, 'not_in', [null, '']] }, { nullable: [ifPath, 'in', [null, '']] }]
+  return [{ required: [ifPath, 'not_in', [null, '', false]] }, { nullable: [ifPath, 'in', [null, '', false]] }]
 }
 
 export const connectionSettingsSchema = new Schema<ConnectionSettings>({
-  sendPDFReportsToOrganisationEmail: { type: Boolean, default: false, required: true },
+  PDFReportsViaEmail: {
+    type: {
+      sendPDFReportsToOrganisationEmail: { type: Boolean, default: false, required: true },
+      locale: { type: String, enum: locales, required: true }
+    },
+    required: true,
+    label: 'PDF via Email'
+  },
   smtp: {
     type: {
       host: { type: String, trim: true, required: true, label: 'Host', rules: requiredIf('smtp.user') },

--- a/backend/models/connectionSettings.ts
+++ b/backend/models/connectionSettings.ts
@@ -1,5 +1,5 @@
 import { HydratedDocument, model, Schema } from 'mongoose'
-import { ConnectionSettings, emailRegex, locales } from '../../common/types.js'
+import { ConnectionSettings, defaultLocale, emailRegex, locales } from '../../common/types.js'
 import { verifyLdapauthConfig, verifySmtpConfig } from '../settingsValidator.js'
 
 function requiredIf(ifPath: string) {
@@ -10,9 +10,10 @@ export const connectionSettingsSchema = new Schema<ConnectionSettings>({
   PDFReportsViaEmail: {
     type: {
       sendPDFReportsToOrganisationEmail: { type: Boolean, default: false, required: true },
-      locale: { type: String, enum: locales, required: true }
+      locale: { type: String, enum: locales, required: true, default: defaultLocale }
     },
     required: true,
+    default: () => ({}),
     label: 'PDF via Email'
   },
   smtp: {
@@ -101,7 +102,8 @@ export const connectionSettingsSchema = new Schema<ConnectionSettings>({
         label: 'LDAP'
       }
     },
-    required: true
+    required: true,
+    default: () => ({})
   }
 })
 

--- a/backend/models/connectionSettings.ts
+++ b/backend/models/connectionSettings.ts
@@ -7,6 +7,7 @@ function requiredIf(ifPath: string) {
 }
 
 export const connectionSettingsSchema = new Schema<ConnectionSettings>({
+  sendPDFReportsToOrganisationEmail: { type: Boolean, default: false, required: true },
   smtp: {
     type: {
       host: { type: String, trim: true, required: true, label: 'Host', rules: requiredIf('smtp.user') },

--- a/backend/models/displaySettings.ts
+++ b/backend/models/displaySettings.ts
@@ -1,5 +1,5 @@
 import { model, Schema } from 'mongoose'
-import { DisplaySettings, Locale, locales } from '../../common/types.js'
+import { defaultLocale, DisplaySettings, Locale, locales } from '../../common/types.js'
 
 const overwrites = {} as { [key in Locale]: { type: typeof Schema.Types.Mixed; required: true; default: () => object } }
 for (const locale of locales) {
@@ -26,8 +26,8 @@ export const displaySettingsSchema = new Schema<DisplaySettings>(
     },
     locale: {
       type: {
-        default: { type: String, enum: locales, required: true },
-        fallback: { type: String, enum: locales, required: true },
+        default: { type: String, enum: locales, required: true, default: defaultLocale },
+        fallback: { type: String, enum: locales, required: true, default: defaultLocale },
         overwrite: { type: overwrites, required: true, description: 'description.keyFullIdentifier' }
       },
       required: true

--- a/backend/models/displaySettings.ts
+++ b/backend/models/displaySettings.ts
@@ -30,8 +30,7 @@ export const displaySettingsSchema = new Schema<DisplaySettings>(
         fallback: { type: String, enum: locales, required: true },
         overwrite: { type: overwrites, required: true, description: 'description.keyFullIdentifier' }
       },
-      required: true,
-      label: 'Sprache'
+      required: true
     }
   },
   { minimize: false, toObject: { minimize: false }, toJSON: { minimize: false } }

--- a/backend/models/organisation.ts
+++ b/backend/models/organisation.ts
@@ -1,9 +1,10 @@
-import { Document, Query, Schema, model } from 'mongoose'
-import { Organisation } from '../../common/types.js'
+import { Document, model, Query, Schema } from 'mongoose'
+import { emailRegex, Organisation } from '../../common/types.js'
 
 export const organisationSchema = new Schema<Organisation>({
   name: { type: String, trim: true, required: true },
   subfolderPath: { type: String, trim: true, default: '' },
+  reportEmail: { type: String, validate: emailRegex },
   bankDetails: { type: String },
   companyNumber: { type: String, trim: true },
   logo: { type: Schema.Types.ObjectId, ref: 'DocumentFile' },

--- a/backend/models/organisation.ts
+++ b/backend/models/organisation.ts
@@ -3,12 +3,12 @@ import { emailRegex, Organisation } from '../../common/types.js'
 
 export const organisationSchema = new Schema<Organisation>({
   name: { type: String, trim: true, required: true },
-  subfolderPath: { type: String, trim: true, default: '' },
   reportEmail: { type: String, validate: emailRegex },
+  website: { type: String },
   bankDetails: { type: String },
   companyNumber: { type: String, trim: true },
   logo: { type: Schema.Types.ObjectId, ref: 'DocumentFile' },
-  website: { type: String }
+  subfolderPath: { type: String, trim: true, default: '' }
 })
 
 function populate(doc: Document) {

--- a/backend/pdf/advance.ts
+++ b/backend/pdf/advance.ts
@@ -1,4 +1,4 @@
-import fs from 'fs'
+import fs from 'fs/promises'
 import pdf_fontkit from 'pdf-fontkit'
 import pdf_lib from 'pdf-lib'
 import { Locale, Money, TravelSimple } from '../../common/types.js'
@@ -9,7 +9,7 @@ export async function generateAdvanceReport(travel: TravelSimple, language: Loca
   formatter.setLocale(language)
   const pdfDoc = await pdf_lib.PDFDocument.create()
   pdfDoc.registerFontkit(pdf_fontkit)
-  const fontBytes = fs.readFileSync('../common/fonts/NotoSans-Regular.ttf')
+  const fontBytes = await fs.readFile('../common/fonts/NotoSans-Regular.ttf')
   const font = await pdfDoc.embedFont(fontBytes, { subset: true })
   const edge = 36
   const fontSize = 11

--- a/backend/pdf/expenseReport.ts
+++ b/backend/pdf/expenseReport.ts
@@ -1,4 +1,4 @@
-import fs from 'fs'
+import fs from 'fs/promises'
 import pdf_fontkit from 'pdf-fontkit'
 import pdf_lib from 'pdf-lib'
 import { addUp } from '../../common/scripts.js'
@@ -21,7 +21,7 @@ export async function generateExpenseReportReport(expenseReport: ExpenseReport, 
   formatter.setLocale(language)
   const pdfDoc = await pdf_lib.PDFDocument.create()
   pdfDoc.registerFontkit(pdf_fontkit)
-  const fontBytes = fs.readFileSync('../common/fonts/NotoSans-Regular.ttf')
+  const fontBytes = await fs.readFile('../common/fonts/NotoSans-Regular.ttf')
   const font = await pdfDoc.embedFont(fontBytes, { subset: true })
   const edge = 36
   const fontSize = 11

--- a/backend/pdf/healthCareCost.ts
+++ b/backend/pdf/healthCareCost.ts
@@ -1,4 +1,4 @@
-import fs from 'fs'
+import fs from 'fs/promises'
 import pdf_fontkit from 'pdf-fontkit'
 import pdf_lib from 'pdf-lib'
 import { addUp } from '../../common/scripts.js'
@@ -21,7 +21,7 @@ export async function generateHealthCareCostReport(healthCareCost: HealthCareCos
   formatter.setLocale(language)
   const pdfDoc = await pdf_lib.PDFDocument.create()
   pdfDoc.registerFontkit(pdf_fontkit)
-  const fontBytes = fs.readFileSync('../common/fonts/NotoSans-Regular.ttf')
+  const fontBytes = await fs.readFile('../common/fonts/NotoSans-Regular.ttf')
   const font = await pdfDoc.embedFont(fontBytes, { subset: true })
   const edge = 36
   const fontSize = 11

--- a/backend/pdf/helper.ts
+++ b/backend/pdf/helper.ts
@@ -14,9 +14,15 @@ import {
   reportIsHealthCareCost,
   reportIsTravel
 } from '../../common/types.js'
+import { getConnectionSettings } from '../db.js'
 import i18n, { formatter } from '../i18n.js'
+import { getClient } from '../mail/mail.js'
 import DocumentFile from '../models/documentFile.js'
 import Organisation from '../models/organisation.js'
+import { generateAdvanceReport } from './advance.js'
+import { generateExpenseReportReport } from './expenseReport.js'
+import { generateHealthCareCostReport } from './healthCareCost.js'
+import { generateTravelReport } from './travel.js'
 
 export async function writeToDiskFilePath(report: Travel | ExpenseReport | HealthCareCost): Promise<string> {
   let path = '/reports/'
@@ -41,6 +47,57 @@ export async function writeToDiskFilePath(report: Travel | ExpenseReport | Healt
   const subfolder = org ? org.subfolderPath : ''
   path += subfolder + report.owner.name.familyName + ' ' + report.owner.name.givenName[0] + ' - ' + report.name + ' ' + totalSum + '.pdf'
   return path
+}
+
+export async function sendViaMail(report: Travel | ExpenseReport | HealthCareCost) {
+  const connectionSettings = await getConnectionSettings()
+  if (connectionSettings.PDFReportsViaEmail.sendPDFReportsToOrganisationEmail) {
+    const org = await Organisation.findOne({ _id: report.project.organisation._id })
+    if (org?.reportEmail) {
+      const mailClient = await getClient()
+      const lng = connectionSettings.PDFReportsViaEmail.locale
+      let subject = '🧾 '
+      let pdf: Uint8Array
+      if (reportIsTravel(report)) {
+        if (report.state == 'refunded') {
+          subject = subject + i18n.t('labels.travel', { lng })
+          pdf = await generateTravelReport(report, lng)
+        } else {
+          subject = subject + i18n.t('labels.advance', { lng })
+          pdf = await generateAdvanceReport(report, lng)
+        }
+      } else if (reportIsHealthCareCost(report)) {
+        subject = subject + i18n.t('labels.healthCareCost', { lng })
+        pdf = await generateHealthCareCostReport(report, lng)
+      } else {
+        subject = subject + i18n.t('labels.expenseReport', { lng })
+        pdf = await generateExpenseReportReport(report, lng)
+      }
+      const appName = i18n.t('headlines.title', { lng }) + ' ' + i18n.t('headlines.emoji', { lng })
+      formatter.setLocale(i18n.language as Locale)
+      const totalSum = formatter.money(addUp(report).total)
+
+      const text =
+        `${i18n.t('labels.project', { lng })}: ${report.project.identifier}\n` +
+        `${i18n.t('labels.name', { lng })}: ${report.name}\n` +
+        `${i18n.t('labels.owner', { lng })}: ${report.owner.name.givenName} ${report.owner.name.familyName}\n` +
+        `${i18n.t('labels.total', { lng })}: ${totalSum}\n`
+
+      return await mailClient.sendMail({
+        from: '"' + appName + '" <' + mailClient.options.from + '>', // sender address
+        to: org?.reportEmail, // list of receivers
+        subject: subject, // Subject line
+        text,
+        attachments: [
+          {
+            content: Buffer.from(pdf),
+            contentType: 'application/pdf',
+            filename: 'report.pdf'
+          }
+        ]
+      })
+    }
+  }
 }
 
 export interface Options {

--- a/backend/pdf/helper.ts
+++ b/backend/pdf/helper.ts
@@ -74,7 +74,7 @@ export async function sendViaMail(report: Travel | ExpenseReport | HealthCareCos
         pdf = await generateExpenseReportReport(report, lng)
       }
       const appName = i18n.t('headlines.title', { lng }) + ' ' + i18n.t('headlines.emoji', { lng })
-      formatter.setLocale(i18n.language as Locale)
+      formatter.setLocale(lng)
       const totalSum = formatter.money(addUp(report).total)
 
       const text =

--- a/backend/pdf/travel.ts
+++ b/backend/pdf/travel.ts
@@ -1,4 +1,4 @@
-import fs from 'fs'
+import fs from 'fs/promises'
 import pdf_fontkit from 'pdf-fontkit'
 import pdf_lib from 'pdf-lib'
 import { addUp } from '../../common/scripts.js'
@@ -39,7 +39,7 @@ export async function generateTravelReport(travel: Travel, language: Locale) {
   formatter.setLocale(language)
   const pdfDoc = await pdf_lib.PDFDocument.create()
   pdfDoc.registerFontkit(pdf_fontkit)
-  const fontBytes = fs.readFileSync('../common/fonts/NotoSans-Regular.ttf')
+  const fontBytes = await fs.readFile('../common/fonts/NotoSans-Regular.ttf')
   const font = await pdfDoc.embedFont(fontBytes, { subset: true })
   const edge = 36
   const fontSize = 11

--- a/backend/retentionpolicy.ts
+++ b/backend/retentionpolicy.ts
@@ -134,7 +134,7 @@ async function sendNotificationMails(report: ITravel | IExpenseReport | IHealthC
 
       const subject = i18n.t(`mail.${reportType}.${report.state}DeletedSoon.subject`, interpolation)
       const paragraph = i18n.t(`mail.${reportType}.${report.state}DeletedSoon.paragraph`, interpolation)
-      await sendMail(recipients, subject, paragraph, button, '')
+      await sendMail(recipients, subject, paragraph, button)
     }
   }
 }

--- a/backend/templates/cache.ts
+++ b/backend/templates/cache.ts
@@ -1,0 +1,18 @@
+import fs from 'fs/promises'
+
+let mail: string | null = null
+let upload: string | null = null
+
+export async function getMailTemplate() {
+  if (!mail) {
+    mail = await fs.readFile('./templates/mail.ejs', { encoding: 'utf-8' })
+  }
+  return mail
+}
+
+export async function getUploadTemplate() {
+  if (!upload) {
+    upload = await fs.readFile('./templates/upload.ejs', { encoding: 'utf-8' })
+  }
+  return upload
+}

--- a/backend/templates/mail.ejs
+++ b/backend/templates/mail.ejs
@@ -350,6 +350,7 @@
                       <td>
                         <p><%= salutation %></p>
                         <p><%= paragraph %></p>
+                        <% if (button) { %>
                         <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary">
                           <tbody>
                             <tr>
@@ -365,6 +366,7 @@
                             </tr>
                           </tbody>
                         </table>
+                        <% } %>
                         <% if (lastParagraph) { %>
                         <p><%= lastParagraph %></p>
                         <% } %>

--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -97,6 +97,7 @@
     "vehicleRegistration": "Lade hier den Fahrzeugschein deines Autos hoch."
   },
   "labels": {
+    "locale": "Sprache",
     "reportEmail": "Email Adresse für Berichte",
     "sendPDFReportsToOrganisationEmail": "PDF Berichte an Organisations-Email senden",
     "access": "Zugriffsrechte",

--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -97,6 +97,8 @@
     "vehicleRegistration": "Lade hier den Fahrzeugschein deines Autos hoch."
   },
   "labels": {
+    "reportEmail": "Email Adresse für Berichte",
+    "sendPDFReportsToOrganisationEmail": "PDF Berichte an Organisations-Email senden",
     "access": "Zugriffsrechte",
     "accessIcons": "Icons für Zugriffsrechte",
     "add": "Hinzufügen",

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -97,6 +97,8 @@
     "vehicleRegistration": "Upload the vehicle registration of your car here."
   },
   "labels": {
+    "reportEmail": "Email Address for Reports",
+    "sendPDFReportsToOrganisationEmail": "Send PDF reports to organisation email",
     "access": "Access",
     "accessIcons": "Icons for access rights",
     "add": "Add",

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -97,6 +97,7 @@
     "vehicleRegistration": "Upload the vehicle registration of your car here."
   },
   "labels": {
+    "locale": "Language",
     "reportEmail": "Email Address for Reports",
     "sendPDFReportsToOrganisationEmail": "Send PDF reports to organisation email",
     "access": "Access",

--- a/common/types.ts
+++ b/common/types.ts
@@ -74,11 +74,13 @@ export interface microsoftSettings {
 }
 
 export interface ConnectionSettings {
+  sendPDFReportsToOrganisationEmail: boolean
   auth: {
     microsoft?: microsoftSettings | null
     ldapauth?: ldapauthSettings | null
   }
   smtp?: smtpSettings | null
+
   _id: _id
 }
 
@@ -211,6 +213,7 @@ export interface ProjectWithUsers extends Project, ProjectUsers {}
 
 export interface Organisation extends OrganisationSimple {
   subfolderPath: string
+  reportEmail?: string | null
   bankDetails?: string | null
   companyNumber?: string | null
   logo?: DocumentFile<ImageType> | null

--- a/common/types.ts
+++ b/common/types.ts
@@ -541,3 +541,4 @@ export const baseCurrency: Currency = {
   subunit: 'Cent',
   symbol: '€'
 }
+export const defaultLocale: Locale = 'de'

--- a/common/types.ts
+++ b/common/types.ts
@@ -74,7 +74,10 @@ export interface microsoftSettings {
 }
 
 export interface ConnectionSettings {
-  sendPDFReportsToOrganisationEmail: boolean
+  PDFReportsViaEmail: {
+    sendPDFReportsToOrganisationEmail: boolean
+    locale: Locale
+  }
   auth: {
     microsoft?: microsoftSettings | null
     ldapauth?: ldapauthSettings | null

--- a/deploy-compose.yml
+++ b/deploy-compose.yml
@@ -4,11 +4,6 @@ services:
     restart: always
     depends_on:
       - db
-    # volumes:
-    # - ./reports/travel:/reports/travel #BACKEND_SAVE_REPORTS_ON_DISK
-    # - ./reports/expenseReport:/reports/expenseReport #BACKEND_SAVE_REPORTS_ON_DISK
-    # - ./reports/advance:/reports/advance #BACKEND_SAVE_REPORTS_ON_DISK
-    # - ./reports/healthCareCost:/reports/healthCareCost #BACKEND_SAVE_REPORTS_ON_DISK
     ports:
       - ${BACKEND_PORT}:${BACKEND_PORT}
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,10 +9,6 @@ services:
     volumes:
       - ./backend:/app
       - ./common:/common
-      # - ./reports/travel:/reports/travel #BACKEND_SAVE_REPORTS_ON_DISK
-      # - ./reports/expenseReport:/reports/expenseReport #BACKEND_SAVE_REPORTS_ON_DISK
-      # - ./reports/advance:/reports/advance #BACKEND_SAVE_REPORTS_ON_DISK
-      # - ./reports/healthCareCost:/reports/healthCareCost #BACKEND_SAVE_REPORTS_ON_DISK
     ports:
       - ${BACKEND_PORT}:${BACKEND_PORT}
       - ${BACKEND_DEBUG_PORT}:${BACKEND_DEBUG_PORT}

--- a/frontend/src/components/settings/elements/ConnectionSettingsForm.vue
+++ b/frontend/src/components/settings/elements/ConnectionSettingsForm.vue
@@ -1,5 +1,10 @@
 <template>
-  <Vueform :schema="schema" ref="form$" :endpoint="false" @submit="(form$: any) => postConnectionSettings(form$.data)"></Vueform>
+  <Vueform
+    :schema="schema"
+    ref="form$"
+    :endpoint="false"
+    @submit="(form$: any) => postConnectionSettings(form$.data)"
+    @keydown.ctrl.s.prevent="() => postConnectionSettings(($refs.form$ as any).data)"></Vueform>
 </template>
 
 <script lang="ts">
@@ -30,21 +35,10 @@ export default defineComponent({
         this.connectionSettings = result.ok
         ;(this.$refs.form$ as any).load(this.connectionSettings)
       }
-    },
-    ctrlS(event: KeyboardEvent) {
-      if (event.ctrlKey && event.key === 's') {
-        event.preventDefault()
-        if (!event.repeat && this.$refs.form$) {
-          this.postConnectionSettings((this.$refs.form$ as any).data)
-        }
-      }
     }
   },
-  beforeDestroy() {
-    document.removeEventListener('keydown', this.ctrlS)
-  },
+
   async mounted() {
-    document.addEventListener('keydown', this.ctrlS)
     await this.$root.load()
     this.schema = Object.assign({}, (await this.$root.getter<any>('admin/connectionSettings/form')).ok?.data, {
       buttons: {

--- a/frontend/src/components/settings/elements/ConnectionSettingsForm.vue
+++ b/frontend/src/components/settings/elements/ConnectionSettingsForm.vue
@@ -4,7 +4,7 @@
     ref="form$"
     :endpoint="false"
     @submit="(form$: any) => postConnectionSettings(form$.data)"
-    @keydown.ctrl.s.prevent="() => postConnectionSettings(($refs.form$ as any).data)"></Vueform>
+    @keydown.ctrl.s.prevent="(e: KeyboardEvent) => {e.repeat ? null: postConnectionSettings(($refs.form$ as any).data)}"></Vueform>
 </template>
 
 <script lang="ts">

--- a/frontend/src/components/settings/elements/ConnectionSettingsForm.vue
+++ b/frontend/src/components/settings/elements/ConnectionSettingsForm.vue
@@ -30,9 +30,21 @@ export default defineComponent({
         this.connectionSettings = result.ok
         ;(this.$refs.form$ as any).load(this.connectionSettings)
       }
+    },
+    ctrlS(event: KeyboardEvent) {
+      if (event.ctrlKey && event.key === 's') {
+        event.preventDefault()
+        if (!event.repeat && this.$refs.form$) {
+          this.postConnectionSettings((this.$refs.form$ as any).data)
+        }
+      }
     }
   },
+  beforeDestroy() {
+    document.removeEventListener('keydown', this.ctrlS)
+  },
   async mounted() {
+    document.addEventListener('keydown', this.ctrlS)
     await this.$root.load()
     this.schema = Object.assign({}, (await this.$root.getter<any>('admin/connectionSettings/form')).ok?.data, {
       buttons: {

--- a/frontend/src/components/settings/elements/DisplaySettingsForm.vue
+++ b/frontend/src/components/settings/elements/DisplaySettingsForm.vue
@@ -1,5 +1,10 @@
 <template>
-  <Vueform :schema="schema" ref="form$" :endpoint="false" @submit="(form$: any) => postDisplaySettings(form$.data)"></Vueform>
+  <Vueform
+    :schema="schema"
+    ref="form$"
+    :endpoint="false"
+    @submit="(form$: any) => postDisplaySettings(form$.data)"
+    @keydown.ctrl.s.prevent="() => postDisplaySettings(($refs.form$ as any).data)"></Vueform>
 </template>
 
 <script lang="ts">
@@ -21,21 +26,9 @@ export default defineComponent({
         this.displaySettings = result.ok
         ;(this.$refs.form$ as any).load(this.displaySettings)
       }
-    },
-    ctrlS(event: KeyboardEvent) {
-      if (event.ctrlKey && event.key === 's') {
-        event.preventDefault()
-        if (!event.repeat && this.$refs.form$) {
-          this.postDisplaySettings((this.$refs.form$ as any).data)
-        }
-      }
     }
   },
-  beforeDestroy() {
-    document.removeEventListener('keydown', this.ctrlS)
-  },
   async mounted() {
-    document.addEventListener('keydown', this.ctrlS)
     await this.$root.load()
     this.schema = Object.assign({}, (await this.$root.getter<any>('admin/displaySettings/form')).ok?.data, {
       buttons: {

--- a/frontend/src/components/settings/elements/DisplaySettingsForm.vue
+++ b/frontend/src/components/settings/elements/DisplaySettingsForm.vue
@@ -4,7 +4,7 @@
     ref="form$"
     :endpoint="false"
     @submit="(form$: any) => postDisplaySettings(form$.data)"
-    @keydown.ctrl.s.prevent="() => postDisplaySettings(($refs.form$ as any).data)"></Vueform>
+    @keydown.ctrl.s.prevent="(e: KeyboardEvent) => {e.repeat ? null: postDisplaySettings(($refs.form$ as any).data)}"></Vueform>
 </template>
 
 <script lang="ts">

--- a/frontend/src/components/settings/elements/DisplaySettingsForm.vue
+++ b/frontend/src/components/settings/elements/DisplaySettingsForm.vue
@@ -21,15 +21,34 @@ export default defineComponent({
         this.displaySettings = result.ok
         ;(this.$refs.form$ as any).load(this.displaySettings)
       }
+    },
+    ctrlS(event: KeyboardEvent) {
+      if (event.ctrlKey && event.key === 's') {
+        event.preventDefault()
+        if (!event.repeat && this.$refs.form$) {
+          this.postDisplaySettings((this.$refs.form$ as any).data)
+        }
+      }
     }
   },
+  beforeDestroy() {
+    document.removeEventListener('keydown', this.ctrlS)
+  },
   async mounted() {
+    document.addEventListener('keydown', this.ctrlS)
     await this.$root.load()
     this.schema = Object.assign({}, (await this.$root.getter<any>('admin/displaySettings/form')).ok?.data, {
       buttons: {
         type: 'group',
         schema: {
-          submit: { type: 'button', submits: true, buttonLabel: this.$t('labels.save'), full: true, columns: { container: 6 } }
+          submit: {
+            type: 'button',
+            submits: true,
+            buttonLabel: this.$t('labels.save'),
+            full: true,
+            columns: { container: 6 },
+            id: 'submit-button'
+          }
         }
       },
       _id: { type: 'hidden', meta: true }

--- a/frontend/src/components/settings/elements/OrganisationList.vue
+++ b/frontend/src/components/settings/elements/OrganisationList.vue
@@ -15,7 +15,7 @@
       ]"
       :headers="[
         { text: $t('labels.name'), value: 'name' },
-        { text: $t('labels.subfolderPath'), value: 'subfolderPath' },
+        { text: $t('labels.reportEmail'), value: 'reportEmail' },
         { text: $t('labels.website'), value: 'website' },
         { value: 'buttons' }
       ]">

--- a/frontend/src/components/settings/elements/SettingsForm.vue
+++ b/frontend/src/components/settings/elements/SettingsForm.vue
@@ -20,9 +20,21 @@ export default defineComponent({
         this.$root.settings = result.ok
         ;(this.$refs.form$ as any).load(this.$root.settings)
       }
+    },
+    ctrlS(event: KeyboardEvent) {
+      if (event.ctrlKey && event.key === 's') {
+        event.preventDefault()
+        if (!event.repeat && this.$refs.form$) {
+          this.postSettings((this.$refs.form$ as any).data)
+        }
+      }
     }
   },
+  beforeDestroy() {
+    document.removeEventListener('keydown', this.ctrlS)
+  },
   async mounted() {
+    document.addEventListener('keydown', this.ctrlS)
     await this.$root.load()
     this.schema = Object.assign({}, (await this.$root.getter<any>('admin/settings/form')).ok?.data, {
       buttons: {

--- a/frontend/src/components/settings/elements/SettingsForm.vue
+++ b/frontend/src/components/settings/elements/SettingsForm.vue
@@ -1,5 +1,10 @@
 <template>
-  <Vueform :schema="schema" ref="form$" :endpoint="false" @submit="(form$: any) => postSettings(form$.data)"></Vueform>
+  <Vueform
+    :schema="schema"
+    ref="form$"
+    :endpoint="false"
+    @submit="(form$: any) => postSettings(form$.data)"
+    @keydown.ctrl.s.prevent="() => postSettings(($refs.form$ as any).data)"></Vueform>
 </template>
 
 <script lang="ts">
@@ -20,21 +25,9 @@ export default defineComponent({
         this.$root.settings = result.ok
         ;(this.$refs.form$ as any).load(this.$root.settings)
       }
-    },
-    ctrlS(event: KeyboardEvent) {
-      if (event.ctrlKey && event.key === 's') {
-        event.preventDefault()
-        if (!event.repeat && this.$refs.form$) {
-          this.postSettings((this.$refs.form$ as any).data)
-        }
-      }
     }
   },
-  beforeDestroy() {
-    document.removeEventListener('keydown', this.ctrlS)
-  },
   async mounted() {
-    document.addEventListener('keydown', this.ctrlS)
     await this.$root.load()
     this.schema = Object.assign({}, (await this.$root.getter<any>('admin/settings/form')).ok?.data, {
       buttons: {

--- a/frontend/src/components/settings/elements/SettingsForm.vue
+++ b/frontend/src/components/settings/elements/SettingsForm.vue
@@ -4,7 +4,7 @@
     ref="form$"
     :endpoint="false"
     @submit="(form$: any) => postSettings(form$.data)"
-    @keydown.ctrl.s.prevent="() => postSettings(($refs.form$ as any).data)"></Vueform>
+    @keydown.ctrl.s.prevent="(e: KeyboardEvent) => {e.repeat ? null: postSettings(($refs.form$ as any).data)}"></Vueform>
 </template>
 
 <script lang="ts">

--- a/frontend/src/formatter.ts
+++ b/frontend/src/formatter.ts
@@ -1,9 +1,10 @@
 import { App, Plugin } from 'vue'
 import Formatter from '../../common/formatter'
+import { defaultLocale } from '../../common/types'
 
 const FormatterPlugin: Plugin = {
   install(app: App, options: any) {
-    app.config.globalProperties.$formatter = new Formatter('de')
+    app.config.globalProperties.$formatter = new Formatter(defaultLocale)
   }
 }
 

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -1,15 +1,17 @@
 import { createI18n } from 'vue-i18n'
-import { Locale, locales } from '../../common/types.js'
+import de from '../../common/locales/de.json' with { type: 'json' }
+import en from '../../common/locales/en.json' with { type: 'json' }
+import { defaultLocale, Locale } from '../../common/types.js'
 
-const emptyMessages = {} as { [key in Locale]: {} }
-for (const locale of locales) {
-  emptyMessages[locale] = {}
+const defaultMessages = {
+  de,
+  en
 }
 
 export default createI18n<any, Locale>({
   legacy: false,
-  locale: 'de',
-  fallbackLocale: 'de',
-  messages: emptyMessages,
+  locale: defaultLocale,
+  fallbackLocale: defaultLocale,
+  messages: defaultMessages,
   globalInjection: true
 })

--- a/frontend/src/vueform.config.ts
+++ b/frontend/src/vueform.config.ts
@@ -3,6 +3,7 @@ import vueform from '@vueform/vueform/dist/vueform'
 import de from '@vueform/vueform/locales/de'
 import en from '@vueform/vueform/locales/en'
 
+import { defaultLocale } from '../../common/types'
 import CountryElement from './components/elements/vueform/CountryElement.vue'
 import CurrencyElement from './components/elements/vueform/CurrencyElement.vue'
 import DocumentfileElement from './components/elements/vueform/DocumentfileElement.vue'
@@ -38,7 +39,7 @@ export default defineConfig({
     MixedElement
   ],
   locales: { de, en },
-  locale: 'de',
+  locale: defaultLocale,
   env: import.meta.env.MODE,
   displayErrors: false,
   displayMessages: false,

--- a/frontend/vue.config.ts
+++ b/frontend/vue.config.ts
@@ -4,16 +4,5 @@ export default {
     client: {
       webSocketURL: 'auto://0.0.0.0:0/ws'
     }
-  },
-  pluginOptions: {
-    i18n: {
-      locale: 'en',
-      fallbackLocale: 'en',
-      localeDir: 'locales',
-      enableLegacy: false,
-      runtimeOnly: false,
-      compositionOnly: false,
-      fullInstall: true
-    }
   }
 }


### PR DESCRIPTION
fixes #117 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced email functionality with the addition of `sendViaMail` to send reports via email.
  - New localization entries for German and English to improve user interface clarity.
  - Added `reportEmail` field to organization settings for storing email addresses related to reports.
  - Introduced `PDFReportsViaEmail` settings for managing PDF report email configurations.
  - Keyboard shortcuts for saving settings in various forms.

- **Bug Fixes**
  - Corrected method naming from `deleteExpenese` to `deleteExpense` for consistency across controllers.

- **Improvements**
  - Updated PDF report generation to use asynchronous file reading for improved performance.
  - Enhanced validation logic in connection settings schema.
  - Simplified function calls by removing redundant parameters in email sending functions.
  - Improved lifecycle management of event listeners in form components.
  - Expanded filtering capabilities in the organization list to include email.
  - Added default locale support for dynamic locale management in various components.

- **Documentation**
  - Added conditional rendering support in email templates for dynamic content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->