### PR TITLE
fix: expand all travel day settings

### DIFF
--- a/frontend/src/components/travel/TravelPage.vue
+++ b/frontend/src/components/travel/TravelPage.vue
@@ -222,7 +222,13 @@
             <div class="col-auto">
               <button
                 class="btn btn-link btn-sm"
-                @click="travel.days.map((d) => ((d as Day).showSettings = true))"
+                @click="
+                  table.map((d) => {
+                    if (d.type === 'day') {
+                      d.data.showSettings = true
+                    }
+                  })
+                "
                 :disabled="travel.stages.length == 0">
                 {{ t('labels.expandAll') }}
                 <i class="bi bi-arrows-expand"></i>
@@ -231,7 +237,13 @@
             <div class="col-auto">
               <button
                 class="btn btn-link btn-sm"
-                @click="travel.days.map((d) => ((d as Day).showSettings = false))"
+                @click="
+                  table.map((d) => {
+                    if (d.type === 'day') {
+                      d.data.showSettings = false
+                    }
+                  })
+                "
                 :disabled="travel.stages.length == 0">
                 {{ t('labels.collapseAll') }}
                 <i class="bi bi-arrows-collapse"></i>

--- a/frontend/src/components/travel/TravelPage.vue
+++ b/frontend/src/components/travel/TravelPage.vue
@@ -223,7 +223,7 @@
               <button
                 class="btn btn-link btn-sm"
                 @click="
-                  table.map((d) => {
+                  table.forEach((d) => {
                     if (d.type === 'day') {
                       d.data.showSettings = true
                     }
@@ -238,7 +238,7 @@
               <button
                 class="btn btn-link btn-sm"
                 @click="
-                  table.map((d) => {
+                  table.forEach((d) => {
                     if (d.type === 'day') {
                       d.data.showSettings = false
                     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the behavior of "Expand All" and "Collapse All" buttons so they now correctly affect only day entries, ensuring more accurate control over day settings in the travel view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->