### PR TITLE
fix: add error message for unsupported file types

### DIFF
--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -29,6 +29,7 @@
     "errorDeleting": "Beim Löschen ist ein Fehler aufgetreten",
     "errorSaving": "Beim Speichern ist ein Fehler aufgetreten",
     "fileXToLargeMaxIsY": "Die Datei '{X}' ist zu groß. Maximalgröße ist {Y}.",
+    "fileTypeOfXNotSupportedY": "Dateityp von '{X}' wird nicht unterstützt. Erlaubt sind: {Y}.",
     "fillOut": "Bitte gib folgende Daten an, damit wir deine Abrechnungen besser zuordnen können.",
     "futureNotAllowed": "Datum darf nicht in der Zukunft liegen",
     "loginFailed": "Anmeldung fehlgeschlagen!",

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -29,6 +29,7 @@
     "errorDeleting": "Error while deleting",
     "errorSaving": "Error while saving",
     "fileXToLargeMaxIsY": "File '{X}' too large. Maximum allowed size is {Y}.",
+    "fileTypeOfXNotSupportedY": "File type of '{X}' not supported. Supported file types are: {Y}.",
     "fillOut": "Please provide the following information so we can better match your statements.",
     "futureNotAllowed": "Date is not allowed to be in the future",
     "loginFailed": "Failed to log in!",

--- a/frontend/src/components/elements/FileUpload.vue
+++ b/frontend/src/components/elements/FileUpload.vue
@@ -57,7 +57,7 @@
 import QRCode from 'qrcode'
 import { defineComponent, PropType } from 'vue'
 import { formatBytes, resizeImage } from '@/../../common/scripts.js'
-import { DocumentFile, Token } from '@/../../common/types.js'
+import { DocumentFile, DocumentFileType, documentFileTypes, Token } from '@/../../common/types.js'
 import API from '@/api.js'
 import APP_LOADER from '@/appData.js'
 import FileUploadFileElement from '@/components/elements/FileUploadFileElement.vue'
@@ -131,15 +131,19 @@ export default defineComponent({
       if (target.files) {
         for (const file of target.files) {
           const maxSize = Number.parseInt(import.meta.env.VITE_MAX_FILE_SIZE)
-          if (file.size < maxSize) {
-            if (file.type.indexOf('image') > -1) {
-              const resizedImage = await resizeImage(file, 1400)
-              files.push({ data: resizedImage, type: resizedImage.type as DocumentFile['type'], name: file.name })
-            } else {
-              files.push({ data: file, type: file.type as DocumentFile['type'], name: file.name })
-            }
-          } else {
+          if (file.size > maxSize) {
             alert(this.$t('alerts.fileXToLargeMaxIsY', { X: file.name, Y: formatBytes(maxSize) }))
+            continue
+          }
+          if (!documentFileTypes.includes(file.type as DocumentFileType)) {
+            alert(this.$t('alerts.fileTypeOfXNotSupportedY', { X: file.name, Y: documentFileTypes.join(', ') }))
+            continue
+          }
+          if (file.type.indexOf('image') > -1) {
+            const resizedImage = await resizeImage(file, 1400)
+            files.push({ data: resizedImage, type: resizedImage.type as DocumentFileType, name: file.name })
+          } else {
+            files.push({ data: file, type: file.type as DocumentFileType, name: file.name })
           }
         }
         target.value = ''


### PR DESCRIPTION
fixes #209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added alerts for unsupported file types during file upload, specifying the file and allowed types in both English and German.

- **Bug Fixes**
  - Improved file upload validation to ensure only files of supported types and sizes are accepted; users are notified if their file does not meet the criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->