### PR TITLE
Fix async database operations

### DIFF
--- a/backend/db.ts
+++ b/backend/db.ts
@@ -165,7 +165,7 @@ async function addLumpSumsToCountries(lumpSumsJSON: LumpSumsJSON) {
           const newLumpSum: CountryLumpSum = Object.assign({ validFrom: new Date(lumpSums.validFrom) }, lumpSum)
           country.lumpSums.push(newLumpSum)
           country.markModified('lumpSums')
-          country.save()
+          await country.save()
           count++
         }
       } else {

--- a/backend/models/exchangeRate.ts
+++ b/backend/models/exchangeRate.ts
@@ -46,7 +46,7 @@ export async function convertCurrency(
       const rates = (res.data as InforEuroResponse).map(
         (r) => ({ currency: r.isoA3Code, value: r.value, month: month, year: year }) as IExchangeRate
       )
-      ExchangeRate.insertMany(rates)
+      await ExchangeRate.insertMany(rates)
       data = rates.find((r) => r.currency === from.toUpperCase())
     }
   }


### PR DESCRIPTION
## Summary
- fix missing `await` in currency conversion when inserting rates
- await saving countries when updating lump sums

## Testing
- `npm run build`
- `npm run _test:development` *(fails: Based on configuration, 11 test files were found but did not match the filters)*

------
https://chatgpt.com/codex/tasks/task_e_685aba63e33883229761afe17b13bd0f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of saving lump sum data for countries by ensuring each save operation completes before proceeding.
  - Enhanced currency conversion accuracy by ensuring new exchange rates are fully saved before attempting to retrieve them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->