### PR TITLE
feat: Make advances deletable when booked and settled

### DIFF
--- a/backend/controller/advanceController.ts
+++ b/backend/controller/advanceController.ts
@@ -39,7 +39,9 @@ export class AdvanceController extends Controller {
   public async deleteOwn(@Query() _id: _id, @Request() request: AuthenticatedExpressRequest) {
     return await this.deleter(Advance, {
       _id: _id,
-      checkOldObject: async (oldObject: AdvanceDoc) => request.user._id.equals(oldObject.owner._id) && oldObject.state < State.BOOKABLE
+      checkOldObject: async (oldObject: AdvanceDoc) =>
+        request.user._id.equals(oldObject.owner._id) &&
+        (oldObject.state < State.BOOKABLE || (oldObject.state === State.BOOKED && Boolean(oldObject.settledOn)))
     })
   }
 

--- a/frontend/src/components/HomePage.vue
+++ b/frontend/src/components/HomePage.vue
@@ -8,19 +8,28 @@
         <template v-if="modalMode === 'view'">
           <TravelApplication v-if="modalObjectType === 'travel'" :travel="(modalObject as TravelSimple)"></TravelApplication>
           <Advance v-else-if="modalObjectType === 'advance'" :advance="(modalObject as AdvanceSimple)"></Advance>
-          <div v-if="modalObject.state !== undefined && modalObject.state <= State.APPLIED_FOR" class="mb-1">
-            <button type="submit" class="btn btn-primary me-2" @click="showModal('edit', modalObjectType, modalObject)">
-              {{ t('labels.edit') }}
-            </button>
-            <button
-              type="button"
-              class="btn btn-danger me-2"
-              @click="deleteReport(modalObjectType as 'travel' | 'advance', modalObject._id as string)">
-              {{ t('labels.delete') }}
-            </button>
-            <button type="button" class="btn btn-light" @click="resetAndHide()">
-              {{ t('labels.cancel') }}
-            </button>
+          <div v-if="modalObject.state !== undefined" class="mb-1">
+            <template v-if="modalObject.state <= State.APPLIED_FOR">
+              <button type="submit" class="btn btn-primary me-2" @click="showModal('edit', modalObjectType, modalObject)">
+                {{ t('labels.edit') }}
+              </button>
+            </template>
+            <template
+              v-if="
+                modalObject.state <= State.APPLIED_FOR ||
+                (modalObject.state === State.BOOKED &&
+                  (modalObjectType === 'travel' || (modalObjectType === 'advance' && Boolean(modalObject.settledOn))))
+              ">
+              <button
+                type="button"
+                class="btn btn-danger me-2"
+                @click="deleteReport(modalObjectType as 'travel' | 'advance', modalObject._id as string)">
+                {{ t('labels.delete') }}
+              </button>
+              <button type="button" class="btn btn-light" @click="resetAndHide()">
+                {{ t('labels.cancel') }}
+              </button>
+            </template>
           </div>
         </template>
         <template v-else>

--- a/frontend/src/components/HomePage.vue
+++ b/frontend/src/components/HomePage.vue
@@ -18,7 +18,7 @@
               v-if="
                 modalObject.state <= State.APPLIED_FOR ||
                 (modalObject.state === State.BOOKED &&
-                  (modalObjectType === 'travel' || (modalObjectType === 'advance' && Boolean(modalObject.settledOn))))
+                  (modalObjectType === 'travel' || (modalObjectType === 'advance' && Boolean((modalObject as AdvanceSimple).settledOn))))
               ">
               <button
                 type="button"

--- a/frontend/src/components/advance/Advance.vue
+++ b/frontend/src/components/advance/Advance.vue
@@ -1,6 +1,6 @@
 <template>
   <StatePipeline class="mb-4" :state="advance.state" :StateEnum="AdvanceState"></StatePipeline>
-  <table class="table mb-4">
+  <table class="table mb-2">
     <tbody>
       <tr>
         <th scope="row">{{ t('labels.owner') }}</th>
@@ -63,7 +63,7 @@
   </table>
   <button
     v-if="advance.state >= State.BOOKABLE"
-    class="btn btn-primary"
+    class="btn btn-primary mb-2"
     @click="
       showFile({
         endpoint: `${props.endpointPrefix}advance/report`,


### PR DESCRIPTION
Fixes #212

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded conditions for deleting or canceling advances, enabling these actions when the advance is in the "BOOKED" state under specific criteria.

* **Style**
  * Refined vertical spacing around the advance table and action buttons for better visual balance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->