### PR TITLE
fix: print too long cells instead of run endless loop

### DIFF
--- a/common/print/printer.ts
+++ b/common/print/printer.ts
@@ -511,6 +511,7 @@ export class PDFDrawer<idType extends _id> {
     opts.yStart = opts.yStart - opts.cellHeight
     opts.newPageYStart = opts.newPageYStart - opts.cellHeight
 
+    let alreadyOnCompletelyNewPage = false
     let x = opts.xStart
     let y = opts.yStart
     for (let i = 0; i < data.length; i++) {
@@ -575,7 +576,7 @@ export class PDFDrawer<idType extends _id> {
         yMin = multiText.bounds.y < yMin ? multiText.bounds.y : yMin
         x = x + column.width
       }
-      if (yMin < this.settings.pagePadding) {
+      if (yMin < this.settings.pagePadding && !alreadyOnCompletelyNewPage) {
         this.currentPage.drawLine({
           // top border ╤
           start: { x: opts.xStart - this.settings.borderThickness, y: opts.yStart + opts.cellHeight - this.settings.borderThickness },
@@ -591,6 +592,7 @@ export class PDFDrawer<idType extends _id> {
           color: this.settings.borderColor
         })
         this.newPage()
+        alreadyOnCompletelyNewPage = true
         x = opts.newPageXStart
         y = opts.newPageYStart
         opts.xStart = opts.newPageXStart
@@ -612,6 +614,7 @@ export class PDFDrawer<idType extends _id> {
           })
         }
       }
+      alreadyOnCompletelyNewPage = false
       for (const border of columnBorders) {
         border.end.y = yMin - this.settings.borderThickness
         this.currentPage.drawLine(border)


### PR DESCRIPTION
Fixes #320

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed table rendering across page breaks in PDF documents to ensure borders and cell content are correctly positioned when tables span multiple pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->