### PR TITLE
Feature: Sanitize connection settings secrets

### DIFF
--- a/backend/controller/connectionSettingsController.ts
+++ b/backend/controller/connectionSettingsController.ts
@@ -4,7 +4,7 @@ import ConnectionSettings, { connectionSettingsSchema } from '../models/connecti
 import { mongooseSchemaToVueformSchema } from '../models/vueformGenerator.js'
 import { Controller } from './controller.js'
 
-const SECRET_PLACEHOLDER = '********'
+export const SECRET_PLACEHOLDER = '********'
 const SECRET_PATHS = ['smtp.password', 'auth.microsoft.clientSecret', 'auth.ldapauth.bindCredentials', 'auth.oidc.clientSecret']
 
 function cloneSettings<T>(value: T): T {

--- a/backend/tests/api/connectionSettings.ts
+++ b/backend/tests/api/connectionSettings.ts
@@ -1,10 +1,10 @@
 import { ConnectionSettings as IConnectionSettings } from 'abrechnung-common/types.js'
 import test, { ExecutionContext } from 'ava'
 import { shutdown } from '../../app.js'
+import { SECRET_PLACEHOLDER } from '../../controller/connectionSettingsController.js'
 import ConnectionSettings from '../../models/connectionSettings.js'
 import createAgent, { loginUser } from '../_agent.js'
 
-const SECRET_PLACEHOLDER = '********'
 const agent = await createAgent()
 await loginUser(agent, 'admin')
 
@@ -29,7 +29,7 @@ function assertSanitizedValue(t: ExecutionContext, data: unknown, original: unkn
   }
 }
 
-test('GET /admin/connectionSettings hides secrets', async (t) => {
+test.serial('GET /admin/connectionSettings hides secrets', async (t) => {
   const existingSettings = await ConnectionSettings.findOne().lean()
   const res = await agent.get('/admin/connectionSettings')
   t.is(res.status, 200)
@@ -41,7 +41,7 @@ test('GET /admin/connectionSettings hides secrets', async (t) => {
   assertSanitizedValue(t, data, existingSettings, ['auth', 'oidc', 'clientSecret'])
 })
 
-test('POST /admin/connectionSettings keeps original secrets when placeholder is sent', async (t) => {
+test.serial('POST /admin/connectionSettings keeps original secrets when placeholder is sent', async (t) => {
   const originalSettings = await ConnectionSettings.findOne().lean()
   const getRes = await agent.get('/admin/connectionSettings')
   t.is(getRes.status, 200)
@@ -62,7 +62,7 @@ test('POST /admin/connectionSettings keeps original secrets when placeholder is 
   assertSanitizedValue(t, postRes.body.result, originalSettings, ['auth', 'oidc', 'clientSecret'])
 })
 
-test('POST /admin/connectionSettings accepts new secret values', async (t) => {
+test.serial('POST /admin/connectionSettings accepts new secret values', async (t) => {
   const getRes = await agent.get('/admin/connectionSettings')
   t.is(getRes.status, 200)
   const settings: IConnectionSettings = getRes.body.data


### PR DESCRIPTION
## Summary
- clone connection settings with JSON serialization to avoid corrupting ObjectIds during sanitization
- continue masking secret fields while preserving stored secrets on update

## Testing
- npm test -- connectionSettings *(fails: missing abrechnung-common dependencies/types in backend build environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943deae72b48322b3272bf4c34a7ec7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connection settings now mask sensitive fields when retrieved.
  * Updating settings with placeholder values preserves original secret values instead of overwriting them.
  * Submitting new secret values updates the store while responses continue to mask secrets.

* **Tests**
  * Added tests verifying masked values on read, secret preservation on update with placeholders, and acceptance of new secrets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->