### PR TITLE
Feature: Add webhook retry configuration options to environment settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,8 +61,8 @@ REDIS_URL=redis://redis:6379
 # WEBHOOK_SCRIPT_RUN_TIMEOUT_MS=100
 # Timeout webhook HTTP requests in milliseconds
 # WEBHOOK_REQUEST_TIMEOUT_MS=5000
-# Number of retry attempts for failed webhook HTTP requests
-# WEBHOOK_RETRY_ATTEMPTS=3
+# Total number of attempts (including initial) for failed webhook HTTP requests
+# WEBHOOK_ATTEMPTS=3
 # Delay between webhook retry attempts in milliseconds. BullMQ exponential: 2 ^ (attempts - 1) * delay
 # WEBHOOK_RETRY_DELAY=120000
 

--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,10 @@ REDIS_URL=redis://redis:6379
 # WEBHOOK_SCRIPT_RUN_TIMEOUT_MS=100
 # Timeout webhook HTTP requests in milliseconds
 # WEBHOOK_REQUEST_TIMEOUT_MS=5000
+# Number of retry attempts for failed webhook HTTP requests
+# WEBHOOK_RETRY_ATTEMPTS=3
+# Delay between webhook retry attempts in milliseconds. BullMQ exponential: 2 ^ (attempts - 1) * delay
+# WEBHOOK_RETRY_DELAY=120000
 
 # REDIS_PREFIX=abrechnung
 

--- a/backend/workers/webhook.ts
+++ b/backend/workers/webhook.ts
@@ -16,8 +16,8 @@ export const webhookQueue = new Queue<WebhookJobData>(WEBHOOK_QUEUE_NAME, {
   connection: { url: ENV.REDIS_URL },
   prefix: ENV.REDIS_PREFIX,
   defaultJobOptions: {
-    attempts: 1,
-    backoff: { type: 'exponential', delay: 5_000 },
+    attempts: ENV.WEBHOOK_RETRY_ATTEMPTS,
+    backoff: { type: 'exponential', delay: ENV.WEBHOOK_RETRY_DELAY },
     removeOnComplete: { count: 3 },
     removeOnFail: { count: 9 }
   }

--- a/backend/workers/webhook.ts
+++ b/backend/workers/webhook.ts
@@ -16,7 +16,7 @@ export const webhookQueue = new Queue<WebhookJobData>(WEBHOOK_QUEUE_NAME, {
   connection: { url: ENV.REDIS_URL },
   prefix: ENV.REDIS_PREFIX,
   defaultJobOptions: {
-    attempts: ENV.WEBHOOK_RETRY_ATTEMPTS,
+    attempts: ENV.WEBHOOK_ATTEMPTS,
     backoff: { type: 'exponential', delay: ENV.WEBHOOK_RETRY_DELAY },
     removeOnComplete: { count: 3 },
     removeOnFail: { count: 9 }

--- a/common/utils/env.ts
+++ b/common/utils/env.ts
@@ -72,7 +72,7 @@ const backendEnvConfig = Object.assign({}, baseEnvConfig, {
   WEBHOOK_SCRIPT_COMPILE_TIMEOUT_MS: int({ default: 50, desc: 'Timeout for compiling user webhook scripts in milliseconds' }),
   WEBHOOK_SCRIPT_RUN_TIMEOUT_MS: int({ default: 100, desc: 'Timeout for running user webhook scripts in milliseconds' }),
   WEBHOOK_REQUEST_TIMEOUT_MS: int({ default: 5_000, desc: 'Timeout webhook HTTP requests in milliseconds' }),
-  WEBHOOK_RETRY_ATTEMPTS: int({ default: 3, desc: 'Number of retry attempts for failed webhook HTTP requests' }),
+  WEBHOOK_ATTEMPTS: int({ default: 3, desc: 'Total number of attempts (including initial) for failed webhook HTTP requests' }),
   WEBHOOK_RETRY_DELAY: int({
     default: 120_000,
     desc: 'Delay between webhook retry attempts in milliseconds. BullMQ exponential: 2 ^ (attempts - 1) * delay'

--- a/common/utils/env.ts
+++ b/common/utils/env.ts
@@ -72,6 +72,11 @@ const backendEnvConfig = Object.assign({}, baseEnvConfig, {
   WEBHOOK_SCRIPT_COMPILE_TIMEOUT_MS: int({ default: 50, desc: 'Timeout for compiling user webhook scripts in milliseconds' }),
   WEBHOOK_SCRIPT_RUN_TIMEOUT_MS: int({ default: 100, desc: 'Timeout for running user webhook scripts in milliseconds' }),
   WEBHOOK_REQUEST_TIMEOUT_MS: int({ default: 5_000, desc: 'Timeout webhook HTTP requests in milliseconds' }),
+  WEBHOOK_RETRY_ATTEMPTS: int({ default: 3, desc: 'Number of retry attempts for failed webhook HTTP requests' }),
+  WEBHOOK_RETRY_DELAY: int({
+    default: 120_000,
+    desc: 'Delay between webhook retry attempts in milliseconds. BullMQ exponential: 2 ^ (attempts - 1) * delay'
+  }),
   PROD_INIT_CONNECTION_SETTINGS: json<Partial<Omit<ConnectionSettings, '_id'>>>({
     default: undefined,
     desc: 'Initial connection settings for production environment as JSON object'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Webhook retry behavior is now configurable via environment variables, enabling custom retry attempts and exponential backoff delays instead of fixed defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->