### PR TITLE
Feature: Beleg Nummern halten interne PDF Links zu den Belegen

### DIFF
--- a/common/print/printer.spec.ts
+++ b/common/print/printer.spec.ts
@@ -1,6 +1,73 @@
 import test from 'ava'
+import { PDFArray, PDFDict, PDFDocument, PDFName, PDFRef, TextAlignment } from 'pdf-lib'
+import Formatter from '../utils/formatter.js'
+import { Column, PDFDrawer } from './printer.js'
 import printerSettings from './printerSettings.js'
 
-test('printerSettings default exist', (t) => {
-  t.truthy(printerSettings)
+const PNG_1X1_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO8LrH8AAAAASUVORK5CYII='
+
+function createDrawer() {
+  const formatter = new Formatter('de', 'givenNameFirst')
+  return PDFDrawer.create(
+    { ...printerSettings, _id: 'printerSettingsId' },
+    async () => null,
+    async () => null,
+    formatter,
+    'de',
+    'portrait'
+  )
+}
+
+test('drawTable creates one internal link annotation per receipt number', async (t) => {
+  const drawer = await createDrawer()
+  const rows = [{ receiptNumbers: ['r1', 'r2'] }]
+  const columns: Column<{ receiptNumbers: string[] }>[] = [
+    { key: 'receiptNumbers', width: 150, alignment: TextAlignment.Left, title: 'Belegnummern' },
+    {
+      key: 'receiptNumbers',
+      width: 100,
+      alignment: TextAlignment.Left,
+      title: 'Belege',
+      fn: () => '1, 2',
+      internalPdfLinkSegments: () => [
+        { text: '1', targetId: 'r1' },
+        { text: '2', targetId: 'r2' }
+      ]
+    }
+  ]
+
+  await drawer.drawTable(rows, columns, { xStart: 30, yStart: 700, fontSize: 9 })
+  const imageData = Buffer.from(PNG_1X1_BASE64, 'base64')
+  await drawer.attachReceipts({
+    r1: { _id: 'r1', number: 1, date: new Date('2026-01-01'), type: 'image/png', data: new Blob([imageData]) },
+    r2: { _id: 'r2', number: 2, date: new Date('2026-01-02'), type: 'image/png', data: new Blob([imageData]) }
+  })
+
+  const pdf = await PDFDocument.load(await drawer.finish())
+  const reportPage = pdf.getPage(0)
+  const annots = reportPage.node.Annots()
+  t.truthy(annots)
+  t.is(annots?.size(), 2)
+
+  const expectedTargets = new Set([pdf.getPage(1).ref.toString(), pdf.getPage(2).ref.toString()])
+  for (let i = 0; i < (annots?.size() || 0); i++) {
+    const annotation = pdf.context.lookup(annots?.get(i), PDFDict)
+    const action = annotation.lookup(PDFName.of('A'), PDFDict)
+    t.is(action.lookup(PDFName.of('S'), PDFName).decodeText(), 'GoTo')
+    const destination = action.lookup(PDFName.of('D'), PDFArray)
+    const targetRef = destination.get(0)
+    t.true(targetRef instanceof PDFRef)
+    t.true(expectedTargets.has(targetRef.toString()))
+  }
+})
+
+test('drawLink appends annotations instead of replacing existing ones', async (t) => {
+  const drawer = await createDrawer()
+  drawer.drawLink('https://example.org/a', { xStart: 10, yStart: 10, width: 20, height: 20 })
+  drawer.drawLink('https://example.org/b', { xStart: 40, yStart: 40, width: 20, height: 20 })
+
+  const pdf = await PDFDocument.load(await drawer.finish())
+  const annots = pdf.getPage(0).node.Annots()
+  t.truthy(annots)
+  t.is(annots?.size(), 2)
 })

--- a/common/print/printer.ts
+++ b/common/print/printer.ts
@@ -7,7 +7,6 @@ import {
   PDFDocument,
   PDFFont,
   PDFImage,
-  PDFName,
   PDFPage,
   PDFPageDrawLineOptions,
   PDFString,
@@ -64,6 +63,8 @@ export interface Column<Type extends {} = any> {
   fn?: (p: any) => string
   // biome-ignore lint/suspicious/noExplicitAny: typing to complex
   countryCodeForFlag?: (p: any) => CountryCode
+  // biome-ignore lint/suspicious/noExplicitAny: typing to complex
+  internalPdfLinkSegments?: (p: any) => { text: string; targetId: string }[]
 }
 
 interface ReceiptMapEntry<idType extends _id, dataType extends binary = binary> {
@@ -196,6 +197,7 @@ export class PDFDrawer<idType extends _id> {
   formatter: Formatter
   settings: PrintSettingsWithColorObjects
   currentPage!: PDFPage
+  pendingInternalLinks: { page: PDFPage; targetId: string; xStart: number; yStart: number; width: number; height: number }[] = []
   getDocumentFileBufferById: (id: idType) => Promise<{ buffer: ArrayBuffer; type: DocumentFileType } | null>
   getOrganisationLogoIdById: (id: idType) => Promise<{ logoId: idType; website?: string | null } | null>
 
@@ -347,6 +349,7 @@ export class PDFDrawer<idType extends _id> {
   }
 
   async attachReceipts(receiptMap: ReceiptMap<idType>) {
+    const receiptFirstPageMap: Record<string, PDFPage> = {}
     for (const receiptId in receiptMap) {
       const receipt = receiptMap[receiptId]
       let doc: { buffer: ArrayBuffer; type: DocumentFileType } | null = null
@@ -361,11 +364,15 @@ export class PDFDrawer<idType extends _id> {
         continue
       }
       try {
+        let firstPageOfReceipt: PDFPage | null = null
         if (receipt.type === 'application/pdf') {
           const insertPDF = await PDFDocument.load(doc.buffer)
           const pages = await this.doc.copyPages(insertPDF, insertPDF.getPageIndices())
           for (const p of pages) {
             this.currentPage = this.doc.addPage(p)
+            if (!firstPageOfReceipt) {
+              firstPageOfReceipt = this.currentPage
+            }
             this.drawReceiptNumber(receipt)
           }
         } else {
@@ -382,6 +389,7 @@ export class PDFDrawer<idType extends _id> {
           } else {
             this.newPage('portrait')
           }
+          firstPageOfReceipt = this.currentPage
           let size = image.scaleToFit(
             this.currentPage.getSize().width - this.settings.pagePadding, // only half padding
             this.currentPage.getSize().height - this.settings.pagePadding
@@ -397,10 +405,30 @@ export class PDFDrawer<idType extends _id> {
           })
           this.drawReceiptNumber(receipt)
         }
+        if (firstPageOfReceipt) {
+          receiptFirstPageMap[receipt._id.toString()] = firstPageOfReceipt
+        }
       } catch (error) {
         console.error(`Error while trying to add Document (${receipt._id})[${doc.type}] to PDF: ${error}`)
       }
     }
+    for (const link of this.pendingInternalLinks) {
+      const targetPage = receiptFirstPageMap[link.targetId]
+      if (!targetPage) {
+        continue
+      }
+      const linkAnnotation = this.doc.context.obj({
+        Type: 'Annot',
+        Subtype: 'Link',
+        Rect: [link.xStart, link.yStart, link.xStart + link.width, link.yStart + link.height],
+        Border: [0, 0, 0],
+        C: [0, 0, 1],
+        A: { Type: 'Action', S: 'GoTo', D: [targetPage.ref, 'Fit'] }
+      })
+      const linkAnnotationRef = this.doc.context.register(linkAnnotation)
+      link.page.node.addAnnot(linkAnnotationRef)
+    }
+    this.pendingInternalLinks = []
   }
 
   async drawFlag(countryCode: CountryCode, options: Options) {
@@ -489,7 +517,7 @@ export class PDFDrawer<idType extends _id> {
       A: { Type: 'Action', S: 'URI', URI: PDFString.of(url) }
     })
     const linkAnnotationRef = this.doc.context.register(linkAnnotation)
-    this.currentPage.node.set(PDFName.of('Annots'), this.doc.context.obj([linkAnnotationRef]))
+    this.currentPage.node.addAnnot(linkAnnotationRef)
   }
 
   async drawTable<Type extends {}>(data: Type[], columns: Column<Type>[], options: TableOptions) {
@@ -522,15 +550,20 @@ export class PDFDrawer<idType extends _id> {
         options: { xStart: number; yStart: number; width: number; fontSize: number }
         countryCodeForFlag?: CountryCode
       }[] = []
+      const cellLinks: { targetId: string; options: { xStart: number; yStart: number; width: number; height: number } }[] = []
       for (const column of columns) {
         const datum = data[i][column.key]
         let cell: string
+        let internalPdfLinkSegments: { text: string; targetId: string }[] = []
         if (opts.firstRow) {
           cell = column.title
         } else {
           cell = String(datum)
           if (column.fn) {
             cell = column.fn(datum)
+          }
+          if (column.internalPdfLinkSegments) {
+            internalPdfLinkSegments = column.internalPdfLinkSegments(datum)
           }
           if (datum === undefined) {
             cell = EMPTY_CELL
@@ -554,6 +587,26 @@ export class PDFDrawer<idType extends _id> {
               fontSize: fontSize
             }
           })
+        }
+        if (!opts.firstRow && internalPdfLinkSegments.length > 0) {
+          let segmentIndex = 0
+          for (const line of multiText.lines) {
+            let lineSearchIndex = 0
+            while (segmentIndex < internalPdfLinkSegments.length) {
+              const segment = internalPdfLinkSegments[segmentIndex]
+              const segmentTextIndex = line.text.indexOf(segment.text, lineSearchIndex)
+              if (segmentTextIndex === -1) {
+                break
+              }
+              const prefix = line.text.slice(0, segmentTextIndex)
+              const width = this.font.widthOfTextAtSize(segment.text, fontSize)
+              const xStart = line.x + this.settings.cellPadding.x + this.font.widthOfTextAtSize(prefix, fontSize)
+              const yStart = line.y + this.settings.cellPadding.bottom
+              cellLinks.push({ targetId: segment.targetId, options: { xStart, yStart, width, height: fontSize } })
+              lineSearchIndex = segmentTextIndex + segment.text.length
+              segmentIndex++
+            }
+          }
         }
         if (multiText.lines.length > 0 && !opts.firstRow) {
           if (column.countryCodeForFlag) {
@@ -612,6 +665,16 @@ export class PDFDrawer<idType extends _id> {
             fontSize: text.options.fontSize
           })
         }
+      }
+      for (const link of cellLinks) {
+        this.pendingInternalLinks.push({
+          page: this.currentPage,
+          targetId: link.targetId,
+          xStart: link.options.xStart,
+          yStart: link.options.yStart,
+          width: link.options.width,
+          height: link.options.height
+        })
       }
       alreadyOnCompletelyNewPage = false
       for (const border of columnBorders) {

--- a/common/print/printer.ts
+++ b/common/print/printer.ts
@@ -558,15 +558,16 @@ export class PDFDrawer<idType extends _id> {
         if (opts.firstRow) {
           cell = column.title
         } else {
-          cell = String(datum)
-          if (column.fn) {
-            cell = column.fn(datum)
-          }
-          if (column.internalPdfLinkSegments) {
-            internalPdfLinkSegments = column.internalPdfLinkSegments(datum)
-          }
           if (datum === undefined) {
             cell = EMPTY_CELL
+          } else {
+            cell = String(datum)
+            if (column.fn) {
+              cell = column.fn(datum)
+            }
+            if (column.internalPdfLinkSegments) {
+              internalPdfLinkSegments = column.internalPdfLinkSegments(datum)
+            }
           }
         }
         const fontSize = opts.firstRow ? opts.fontSize + 1 : opts.fontSize
@@ -609,7 +610,7 @@ export class PDFDrawer<idType extends _id> {
           }
         }
         if (multiText.lines.length > 0 && !opts.firstRow) {
-          if (column.countryCodeForFlag) {
+          if (column.countryCodeForFlag && datum !== undefined) {
             cellTexts[cellTexts.length - 1].text = cellTexts[cellTexts.length - 1].text.slice(
               0,
               cellTexts[cellTexts.length - 1].text.length - FLAG_PSEUDO_SUFFIX.length

--- a/common/print/reportPrinter.ts
+++ b/common/print/reportPrinter.ts
@@ -422,6 +422,16 @@ class ReportPrint<idType extends _id> {
     return await this.drawer.drawTable<{ author: Comment['author'] | string; text: string }>(rows, columns, tableOptions)
   }
 
+  getReceiptNumberLinkSegments(cost: Cost, receiptMap: ReceiptMap<idType>) {
+    return cost.receipts
+      .filter((r) => receiptMap[(r._id as _id).toString()]) // if vehicle registration is 'none', receipts for ownCar stages are not included
+      .map((r) => {
+        // receipts always have an _id in backend
+        const id = (r._id as _id).toString()
+        return { text: receiptMap[id].number.toString(), targetId: id }
+      })
+  }
+
   async drawStages(receiptMap: ReceiptMap<idType>, options: Options, drawNotes = true) {
     if (!reportIsTravel(this.report) || this.report.stages.length === 0) {
       return options.yStart
@@ -499,17 +509,10 @@ class ReportPrint<idType extends _id> {
       alignment: TextAlignment.Left,
       title: this.t('labels.receiptNumber'),
       fn: (m: Cost) =>
-        m.receipts
-          .filter((r) => receiptMap[(r._id as _id).toString()]) // if vehicle registration is 'none', receipts for ownCar stages are not included
-          .map((r) => receiptMap[(r._id as _id).toString()].number) // receipts always have an _id in backend
+        this.getReceiptNumberLinkSegments(m, receiptMap)
+          .map((segment) => segment.text)
           .join(', '),
-      internalPdfLinkSegments: (m: Cost) =>
-        m.receipts
-          .filter((r) => receiptMap[(r._id as _id).toString()])
-          .map((r) => {
-            const id = (r._id as _id).toString()
-            return { text: receiptMap[id].number.toString(), targetId: id }
-          })
+      internalPdfLinkSegments: (m: Cost) => this.getReceiptNumberLinkSegments(m, receiptMap)
     })
 
     const fontSize = options.fontSize + 2
@@ -558,12 +561,11 @@ class ReportPrint<idType extends _id> {
       width: 45,
       alignment: TextAlignment.Left,
       title: this.t('labels.receiptNumber'),
-      fn: (m: Cost) => m.receipts.map((r) => receiptMap[(r._id as _id).toString()].number).join(', '), // receipts always have an _id in backend
-      internalPdfLinkSegments: (m: Cost) =>
-        m.receipts.map((r) => {
-          const id = (r._id as _id).toString()
-          return { text: receiptMap[id].number.toString(), targetId: id }
-        })
+      fn: (m: Cost) =>
+        this.getReceiptNumberLinkSegments(m, receiptMap)
+          .map((segment) => segment.text)
+          .join(', '),
+      internalPdfLinkSegments: (m: Cost) => this.getReceiptNumberLinkSegments(m, receiptMap)
     })
 
     const fontSize = options.fontSize + 2

--- a/common/print/reportPrinter.ts
+++ b/common/print/reportPrinter.ts
@@ -502,7 +502,14 @@ class ReportPrint<idType extends _id> {
         m.receipts
           .filter((r) => receiptMap[(r._id as _id).toString()]) // if vehicle registration is 'none', receipts for ownCar stages are not included
           .map((r) => receiptMap[(r._id as _id).toString()].number) // receipts always have an _id in backend
-          .join(', ')
+          .join(', '),
+      internalPdfLinkSegments: (m: Cost) =>
+        m.receipts
+          .filter((r) => receiptMap[(r._id as _id).toString()])
+          .map((r) => {
+            const id = (r._id as _id).toString()
+            return { text: receiptMap[id].number.toString(), targetId: id }
+          })
     })
 
     const fontSize = options.fontSize + 2
@@ -551,7 +558,12 @@ class ReportPrint<idType extends _id> {
       width: 45,
       alignment: TextAlignment.Left,
       title: this.t('labels.receiptNumber'),
-      fn: (m: Cost) => m.receipts.map((r) => receiptMap[(r._id as _id).toString()].number).join(', ') // receipts always have an _id in backend
+      fn: (m: Cost) => m.receipts.map((r) => receiptMap[(r._id as _id).toString()].number).join(', '), // receipts always have an _id in backend
+      internalPdfLinkSegments: (m: Cost) =>
+        m.receipts.map((r) => {
+          const id = (r._id as _id).toString()
+          return { text: receiptMap[id].number.toString(), targetId: id }
+        })
     })
 
     const fontSize = options.fontSize + 2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clickable internal PDF links in tables and receipt lists, allowing navigation to the first page of referenced receipts or embedded content.
  * Batched link handling to ensure multiple links can be added without overwriting existing annotations.

* **Tests**
  * Expanded PDF drawing tests to verify per-receipt link creation, correct annotation counts, and proper link destinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->