### PR TITLE
chore: update Dockerfiles and configuration to run containers as non-root user

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,3 +78,9 @@ REDIS_URL=redis://redis:6379
 # ⚠️Deprecated⚠️ Use send via mail under connection settings
 # If set to 'true', all reports will be saved to `/reports` in the worker container.
 # BACKEND_SAVE_REPORTS_ON_DISK=false
+
+
+# Optional host UID/GID mapping for Linux bind mounts (avoid root-owned files in ./backend ./frontend ./common)
+# Set with: HOST_UID=$(id -u) and HOST_GID=$(id -g)
+# HOST_UID=1000
+# HOST_GID=1000

--- a/.github/actions/setup-development-env/action.yml
+++ b/.github/actions/setup-development-env/action.yml
@@ -1,0 +1,35 @@
+name: Setup Development Environment
+description: Copy .env.example file and set HOST_UID/HOST_GID for docker compose development runs
+
+runs:
+  using: 'composite'
+  steps:
+    - name: copy .env file
+      uses: canastro/copy-file-action@ae66602ce7d214dbd2e298c1db67a81388755a0a
+      with:
+        source: '.env.example'
+        target: '.env'
+    - name: Set host user mapping in .env
+      shell: bash
+      run: |
+        uid="$(id -u)"
+        gid="$(id -g)"
+        if [ -n "$(tail -c 1 .env)" ]; then
+          echo >> .env
+        fi
+
+        if grep -q '^HOST_UID=' .env; then
+          sed -i "s/^HOST_UID=.*/HOST_UID=${uid}/" .env
+        elif grep -q '^# HOST_UID=' .env; then
+          sed -i "s/^# HOST_UID=.*/HOST_UID=${uid}/" .env
+        else
+          echo "HOST_UID=${uid}" >> .env
+        fi
+
+        if grep -q '^HOST_GID=' .env; then
+          sed -i "s/^HOST_GID=.*/HOST_GID=${gid}/" .env
+        elif grep -q '^# HOST_GID=' .env; then
+          sed -i "s/^# HOST_GID=.*/HOST_GID=${gid}/" .env
+        else
+          echo "HOST_GID=${gid}" >> .env
+        fi

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,11 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: copy .env file
-        uses: canastro/copy-file-action@ae66602ce7d214dbd2e298c1db67a81388755a0a # master
-        with:
-          source: ".env.example"
-          target: ".env"
+      - uses: ./.github/actions/setup-development-env
       - name: Start dev Environment
         run: docker compose up -d common db redis ldap inbucket
       - name: Run common tests

--- a/backend/Dockerfile.development
+++ b/backend/Dockerfile.development
@@ -12,8 +12,7 @@ RUN mkdir -p /reports && chown node:node /reports
 
 WORKDIR /npm_cache
 COPY backend/package*.json ./
-RUN npm install
-RUN chown -R node:node /npm_cache
+RUN npm install && chown -R node:node /npm_cache && mkdir -p /app && chown node:node /app
 
 WORKDIR /app
 

--- a/backend/Dockerfile.development
+++ b/backend/Dockerfile.development
@@ -8,14 +8,16 @@ RUN apk add --no-cache tini
 COPY backend/docker-entrypoint.development.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-RUN mkdir /reports
+RUN mkdir -p /reports && chown node:node /reports
 
 WORKDIR /npm_cache
 COPY backend/package*.json ./
 RUN npm install
+RUN chown -R node:node /npm_cache
 
 WORKDIR /app
 
+USER node
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/docker-entrypoint.sh"]
 
 CMD ["npm", "run", "dev"]

--- a/backend/Dockerfile.production
+++ b/backend/Dockerfile.production
@@ -4,7 +4,7 @@ LABEL org.opencontainers.image.source=https://github.com/david-loe/abrechnung
 LABEL org.opencontainers.image.description="abrechnung🧾 backend"
 LABEL org.opencontainers.image.licenses=AGPL-3.0-only
 
-RUN mkdir /reports
+RUN mkdir -p /reports && chown node:node /reports && chmod 775 /reports
 
 WORKDIR /build
 
@@ -20,4 +20,7 @@ COPY backend/ .
 
 RUN npm run build
 
+RUN chown -R node:node /build
+
+USER node
 CMD ["npm", "run", "start"]

--- a/common/Dockerfile.development
+++ b/common/Dockerfile.development
@@ -8,9 +8,11 @@ LABEL org.opencontainers.image.licenses=AGPL-3.0-only
 WORKDIR /npm_cache
 COPY package*.json ./
 RUN npm install
+RUN chown -R node:node /npm_cache
 
 WORKDIR /app
 
+USER node
 ENTRYPOINT [ "/bin/sh", "-c", "cp -r /npm_cache/node_modules/. /app/node_modules && exec \"$0\" \"$@\"" ]
 
 CMD ["npm", "run", "dev"]

--- a/deploy-compose.yml
+++ b/deploy-compose.yml
@@ -22,13 +22,13 @@ services:
     depends_on:
       - backend
     healthcheck:
-      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:80/"]
+      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:8080/"]
       interval: 30s
       timeout: 5s
       retries: 3
       start_period: 20s
     ports:
-      - ${FRONTEND_PORT}:80
+      - ${FRONTEND_PORT}:8080
     env_file:
       - .env
   

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     build:
       context: ./
       dockerfile: ./backend/Dockerfile.${NODE_ENV}
+    user: "${HOST_UID:-1000}:${HOST_GID:-1000}"
     restart: always
     depends_on:
       - db
@@ -21,6 +22,7 @@ services:
     build:
       context: ./
       dockerfile: ./frontend/Dockerfile.${NODE_ENV}
+    user: "${HOST_UID:-1000}:${HOST_GID:-1000}"
     volumes:
       - ./frontend:/app
       - ./common:/common:ro
@@ -52,6 +54,7 @@ services:
     build:
       context: ./common
       dockerfile: Dockerfile.${NODE_ENV}
+    user: "${HOST_UID:-1000}:${HOST_GID:-1000}"
     volumes:
       - ./common:/app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     depends_on:
       - backend
     ports:
-      - ${FRONTEND_PORT:-5000}:80
+      - ${FRONTEND_PORT:-5000}:8080
     env_file:
       - .env
   db:

--- a/frontend/Dockerfile.development
+++ b/frontend/Dockerfile.development
@@ -7,9 +7,11 @@ LABEL org.opencontainers.image.licenses=AGPL-3.0-only
 WORKDIR /npm_cache
 COPY frontend/package*.json ./
 RUN npm install
+RUN chown -R node:node /npm_cache
 
 WORKDIR /app
 
+USER node
 ENTRYPOINT [ "/bin/sh", "-c", "cp -r /npm_cache/node_modules/. /app/node_modules && exec \"$0\" \"$@\"" ]
 
 CMD ["npm", "run", "dev"]

--- a/frontend/Dockerfile.production
+++ b/frontend/Dockerfile.production
@@ -11,6 +11,8 @@ COPY frontend/nginx.conf /etc/nginx/nginx.conf
 
 WORKDIR /app
 
+ENV HOME=/home/node
+
 COPY common ../common
 RUN npm install --prefix ../common
 RUN npm run --prefix ../common build
@@ -21,6 +23,9 @@ RUN npm install
 
 COPY frontend/ .
 
+RUN mkdir -p /home/node && chown -R node:node /home/node /app
+
+USER node
 ENTRYPOINT [ "/bin/sh", "-c" ]
 
-CMD ["npm run build && nginx -g 'daemon off;'"]
+CMD ["npm run build && nginx -e /dev/stderr -g 'daemon off;'"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,6 +1,6 @@
-user  nginx;
 worker_processes  1;
-error_log  /var/log/nginx/error.log warn;
+pid /tmp/nginx.pid;
+error_log /dev/stderr warn;
 events {
   worker_connections  1024;
 }
@@ -10,11 +10,16 @@ http {
   log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                     '$status $body_bytes_sent "$http_referer" '
                     '"$http_user_agent" "$http_x_forwarded_for"';
-  access_log  /var/log/nginx/access.log  main;
+  access_log /dev/stdout main;
+  client_body_temp_path /tmp/nginx-client-temp;
+  proxy_temp_path /tmp/nginx-proxy-temp;
+  fastcgi_temp_path /tmp/nginx-fastcgi-temp;
+  uwsgi_temp_path /tmp/nginx-uwsgi-temp;
+  scgi_temp_path /tmp/nginx-scgi-temp;
   sendfile        on;
   keepalive_timeout  65;
   server {
-    listen       80;
+    listen       8080;
     server_name  localhost;
     location / {
       root   /app/dist;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -23,13 +23,13 @@ export default {
     })
   ],
   server: {
-    port: 80,
+    port: 8080,
     strictPort: true,
     host: '0.0.0.0',
     allowedHosts: [process.env.VITE_FRONTEND_URL?.replace(/^https?:\/\//, '')],
     fs: { allow: [searchForWorkspaceRoot(process.cwd()), '../common'] }
   },
-  preview: { port: 80, host: '0.0.0.0' },
+  preview: { port: 8080, host: '0.0.0.0' },
   resolve: { alias: { '@': resolve(__dirname, './src') } },
   build: { rollupOptions: { output: { entryFileNames: 'app-[hash].js' } } }
 }


### PR DESCRIPTION
### One-Time Ownership Cleanup (Linux)

If the repository already contains root-owned build artifacts from earlier Docker runs, fix ownership once:

```bash
sudo chown -R "$(id -u):$(id -g)" common/dist common/node_modules backend/node_modules frontend/node_modules
```

Then verify:

```bash
ls -ld common/dist common/node_modules backend/node_modules frontend/node_modules
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Changes**
  * Updated frontend application to run on port 8080 instead of port 80.
  * Enhanced container security with non-root user execution across development and production environments.
  * Improved logging configuration for better container observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->