### PR TITLE
Feature: delete advances while not linked or booked

### DIFF
--- a/backend/controller/advanceController.ts
+++ b/backend/controller/advanceController.ts
@@ -7,7 +7,11 @@ import { reportPrinter } from '../factory.js'
 import { checkIfUserIsProjectSupervisor, setAdvanceBalance } from '../helper.js'
 import i18n from '../i18n.js'
 import { emitIntegrationEvent } from '../integrations/dispatcher.js'
+import { sendAdvanceDeletionNotification } from '../integrations/notifications/status.js'
 import Advance, { AdvanceDoc } from '../models/advance.js'
+import ExpenseReport from '../models/expenseReport.js'
+import HealthCareCost from '../models/healthCareCost.js'
+import Travel from '../models/travel.js'
 import { Controller, checkOwner, GetterQuery } from './controller.js'
 import { AuthorizationError, NotFoundError } from './error.js'
 import { AuthenticatedExpressRequest, MoneyPost } from './types.js'
@@ -152,6 +156,29 @@ export class AdvanceApproveController extends Controller {
       filter.$and?.push({ project: { $in: request.user.projects.supervised as any } })
     }
     return await this.getter(Advance, { query, filter, projection: { history: 0, historic: 0 }, sort: { updatedAt: -1 } })
+  }
+
+  @Delete()
+  public async deleteApproved(@Query() _id: string, @Request() request: AuthenticatedExpressRequest) {
+    const result = await this.deleter(Advance, {
+      _id,
+      referenceChecks: [
+        { model: Travel, paths: ['advances'], conditions: { historic: false } },
+        { model: ExpenseReport, paths: ['advances'], conditions: { historic: false } },
+        { model: HealthCareCost, paths: ['advances'], conditions: { historic: false } }
+      ],
+      cb: async (deleteResult) => {
+        if (deleteResult.deletedCount === 1) {
+          await sendAdvanceDeletionNotification(deleteResult.deletedObject, request.user)
+        }
+      },
+      checkOldObject: async (oldObject: AdvanceDoc) =>
+        !oldObject.historic &&
+        oldObject.state === AdvanceState.APPROVED &&
+        oldObject.offsetAgainst.length === 0 &&
+        checkIfUserIsProjectSupervisor(request.user, oldObject.project._id)
+    })
+    return result
   }
 
   @Post('approved')

--- a/backend/controller/advanceController.ts
+++ b/backend/controller/advanceController.ts
@@ -175,6 +175,7 @@ export class AdvanceApproveController extends Controller {
       checkOldObject: async (oldObject: AdvanceDoc) =>
         !oldObject.historic &&
         oldObject.state === AdvanceState.APPROVED &&
+        !oldObject.receivedOn &&
         oldObject.offsetAgainst.length === 0 &&
         checkIfUserIsProjectSupervisor(request.user, oldObject.project._id)
     })

--- a/backend/controller/controller.ts
+++ b/backend/controller/controller.ts
@@ -175,7 +175,6 @@ export interface DeleterForArrayElemetQuery extends DeleterQuery {
 
 // biome-ignore lint/suspicious/noExplicitAny: to complex typing
 export interface DeleterForArrayElemetOptions<ModelType, ArrayElementType, ModelMethods = any> extends DeleterForArrayElemetQuery {
-  // biome-ignore lint/suspicious/noExplicitAny: to complex typing
   cb?: (data: ArrayElementType) => unknown
   checkOldObject?: (oldObject: HydratedDocument<ModelType> & ModelMethods) => Promise<boolean>
   arrayElementKey: keyof ModelType

--- a/backend/controller/controller.ts
+++ b/backend/controller/controller.ts
@@ -165,7 +165,7 @@ export interface DeleterOptions<ModelType, ModelMethods = any> extends DeleterQu
   // biome-ignore lint/suspicious/noExplicitAny: to complex typing
   referenceChecks?: { paths: string[]; model: Model<any>; conditions?: { [key: string]: any } }[]
   minDocumentCount?: number
-  cb?: (data: DeleteResult) => unknown
+  cb?: (data: DeleteResult & { deletedObject: ModelType }) => unknown
   checkOldObject?: (oldObject: HydratedDocument<ModelType> & ModelMethods) => Promise<boolean>
 }
 
@@ -354,12 +354,12 @@ export class Controller extends TsoaController {
         }
       }
     }
-
-    const result = await doc.deleteOne()
+    const deletedObject = doc.toObject()
+    const deleteResult = await doc.deleteOne()
     if (options.cb) {
-      options.cb(result)
+      await options.cb({ ...deleteResult, deletedObject })
     }
-    return result
+    return deleteResult
   }
 
   async deleterForArrayElement<ModelType, ArrayElementType extends { _id: Types.ObjectId }>(
@@ -391,7 +391,7 @@ export class Controller extends TsoaController {
     parentObject.markModified(options.arrayElementKey)
     const result: ModelType = (await parentObject.save()).toObject()
     if (options.cb) {
-      options.cb({ acknowledged: true, deletedCount: 1 })
+      await options.cb({ acknowledged: true, deletedCount: 1, deletedObject: result })
     }
     return { message: 'alerts.successDeleting', result: result }
   }

--- a/backend/controller/controller.ts
+++ b/backend/controller/controller.ts
@@ -173,7 +173,13 @@ export interface DeleterForArrayElemetQuery extends DeleterQuery {
   parentId: string
 }
 
-export interface DeleterForArrayElemetOptions<ModelType, ArrayElementType> extends DeleterOptions<ModelType>, DeleterForArrayElemetQuery {
+// biome-ignore lint/suspicious/noExplicitAny: to complex typing
+export interface DeleterForArrayElemetOptions<ModelType, ArrayElementType, ModelMethods = any> extends DeleterForArrayElemetQuery {
+  // biome-ignore lint/suspicious/noExplicitAny: to complex typing
+  referenceChecks?: { paths: string[]; model: Model<any>; conditions?: { [key: string]: any } }[]
+  minDocumentCount?: number
+  cb?: (data: DeleteResult & { deletedElement: ArrayElementType }) => unknown
+  checkOldObject?: (oldObject: HydratedDocument<ModelType> & ModelMethods) => Promise<boolean>
   arrayElementKey: keyof ModelType
   beforeDelete?(element: ArrayElementType): Promise<unknown>
 }
@@ -373,25 +379,25 @@ export class Controller extends TsoaController {
     if (options.checkOldObject && !(await options.checkOldObject(parentObject))) {
       throw new NotAllowedError(`Not allowed to modify this ${model.modelName} - ${String(options.arrayElementKey)}`)
     }
-    let found = false
+    let deletedElement: ArrayElementType | undefined
     const arr = parentObject[options.arrayElementKey] as Array<ArrayElementType>
     for (let i = 0; i < arr.length; i++) {
       if (arr[i]._id.equals(options._id)) {
-        found = true
         if (options.beforeDelete) {
           await options.beforeDelete(arr[i])
         }
+        deletedElement = arr[i]
         arr.splice(i, 1)
         break
       }
     }
-    if (!found) {
+    if (!deletedElement) {
       throw new NotFoundError(`No ${model.modelName} - ${String(options.arrayElementKey)} for _id: '${options._id}' found.`)
     }
     parentObject.markModified(options.arrayElementKey)
     const result: ModelType = (await parentObject.save()).toObject()
     if (options.cb) {
-      await options.cb({ acknowledged: true, deletedCount: 1, deletedObject: result })
+      await options.cb({ acknowledged: true, deletedCount: 1, deletedElement })
     }
     return { message: 'alerts.successDeleting', result: result }
   }

--- a/backend/controller/controller.ts
+++ b/backend/controller/controller.ts
@@ -176,9 +176,7 @@ export interface DeleterForArrayElemetQuery extends DeleterQuery {
 // biome-ignore lint/suspicious/noExplicitAny: to complex typing
 export interface DeleterForArrayElemetOptions<ModelType, ArrayElementType, ModelMethods = any> extends DeleterForArrayElemetQuery {
   // biome-ignore lint/suspicious/noExplicitAny: to complex typing
-  referenceChecks?: { paths: string[]; model: Model<any>; conditions?: { [key: string]: any } }[]
-  minDocumentCount?: number
-  cb?: (data: DeleteResult & { deletedElement: ArrayElementType }) => unknown
+  cb?: (data: ArrayElementType) => unknown
   checkOldObject?: (oldObject: HydratedDocument<ModelType> & ModelMethods) => Promise<boolean>
   arrayElementKey: keyof ModelType
   beforeDelete?(element: ArrayElementType): Promise<unknown>
@@ -363,7 +361,7 @@ export class Controller extends TsoaController {
     const deletedObject = doc.toObject()
     const deleteResult = await doc.deleteOne()
     if (options.cb) {
-      await options.cb({ ...deleteResult, deletedObject })
+      options.cb({ ...deleteResult, deletedObject })
     }
     return deleteResult
   }
@@ -397,7 +395,7 @@ export class Controller extends TsoaController {
     parentObject.markModified(options.arrayElementKey)
     const result: ModelType = (await parentObject.save()).toObject()
     if (options.cb) {
-      await options.cb({ acknowledged: true, deletedCount: 1, deletedElement })
+      options.cb(deletedElement)
     }
     return { message: 'alerts.successDeleting', result: result }
   }

--- a/backend/integrations/notifications/status.ts
+++ b/backend/integrations/notifications/status.ts
@@ -7,6 +7,7 @@ import {
   HealthCareCostState,
   User as IUser,
   Locale,
+  ProjectSimpleWithName,
   ReportType,
   reportIsAdvance,
   reportIsHealthCareCost,
@@ -24,7 +25,7 @@ import i18n from '../../i18n.js'
 import User from '../../models/user.js'
 import { type IntegrationEventHandlerMap } from '../events.js'
 import { Integration } from '../integration.js'
-import { enqueueMail } from './email.js'
+import { enqueueMail, type MailRecipient } from './email.js'
 import { enqueuePushNotification } from './push.js'
 
 class StatusNotificationIntegration extends Integration {
@@ -44,6 +45,58 @@ class StatusNotificationIntegration extends Integration {
 }
 
 export const statusNotificationIntegration = new StatusNotificationIntegration()
+
+function dedupeRecipients(recipients: MailRecipient[]) {
+  const uniqueRecipients = new Map<string, MailRecipient>()
+  for (const recipient of recipients) {
+    uniqueRecipients.set(recipient.email, recipient)
+  }
+  return [...uniqueRecipients.values()]
+}
+
+export async function getAdvanceDeletionMailRecipients(advance: Pick<Advance<Types.ObjectId>, 'owner' | 'project'>) {
+  const supervisedProjectsFilter = { $or: [{ 'projects.supervised': [] }, { 'projects.supervised': advance.project._id }] }
+  const [owner, bookers] = await Promise.all([
+    User.findOne({ _id: advance.owner._id }).lean(),
+    User.find({ 'access.book/advance': true, ...supervisedProjectsFilter }).lean()
+  ])
+
+  return dedupeRecipients([...(owner ? [owner] : []), ...bookers])
+}
+
+export async function sendAdvanceDeletionNotification(
+  advance: Pick<Advance<Types.ObjectId>, '_id' | 'name' | 'owner' | 'project'>,
+  deletedBy: Pick<IUser<Types.ObjectId, mongo.Binary>, 'name'>
+) {
+  const recipients = await getAdvanceDeletionMailRecipients(advance)
+  if (recipients.length === 0) {
+    return
+  }
+
+  const recipientsByLanguage = new Map<Locale, MailRecipient[]>()
+  for (const recipient of recipients) {
+    const usersForLanguage = recipientsByLanguage.get(recipient.settings.language) ?? []
+    usersForLanguage.push(recipient)
+    recipientsByLanguage.set(recipient.settings.language, usersForLanguage)
+  }
+
+  const project = advance.project as ProjectSimpleWithName<Types.ObjectId>
+  for (const [language, localizedRecipients] of recipientsByLanguage) {
+    const interpolation = {
+      deletedBy: deletedBy.name.givenName,
+      lng: language,
+      owner: advance.owner.name.givenName,
+      project: `${project.identifier}${project.name ? ` ${project.name}` : ''}`,
+      reportName: advance.name
+    }
+
+    await enqueueMail(
+      localizedRecipients,
+      i18n.t('mail.advance.DELETED.subject', interpolation),
+      i18n.t('mail.advance.DELETED.paragraph', interpolation)
+    )
+  }
+}
 
 export async function sendStatusNotification(
   report: TravelSimple | ExpenseReportSimple | HealthCareCostSimple | Advance,

--- a/backend/tests/api/advance.ts
+++ b/backend/tests/api/advance.ts
@@ -61,6 +61,11 @@ async function deleteApprovedAdvance(_id: string) {
   return await agent.delete('/approve/advance').query({ _id })
 }
 
+async function confirmAdvanceReceipt(_id: string, receivedOn = new Date('2024-05-05T00:00:00.000Z')) {
+  await loginUser(agent, 'user')
+  return await agent.post('/advance/received').send({ _id, receivedOn })
+}
+
 test.serial('load shared fixtures', async (t) => {
   await loginUser(agent, 'user')
   const [projectResponse, categoryResponse, insuranceResponse] = await Promise.all([
@@ -106,6 +111,21 @@ test.serial('DELETE /approve/advance deletes approver-created advance and dedupl
   const deleteResponse = await deleteApprovedAdvance(advance._id)
   t.is(deleteResponse.status, 200)
   t.is(deleteResponse.body.deletedCount, 1)
+})
+
+test.serial('DELETE /approve/advance rejects deletion after receipt was confirmed', async (t) => {
+  const createdResponse = await createAppliedAdvance('Received advance')
+  t.is(createdResponse.status, 200)
+  const advance = createdResponse.body.result as { _id: string }
+
+  const approvedResponse = await approveAdvance(advance._id)
+  t.is(approvedResponse.status, 200)
+
+  const receivedResponse = await confirmAdvanceReceipt(advance._id)
+  t.is(receivedResponse.status, 200)
+
+  const deleteResponse = await deleteApprovedAdvance(advance._id)
+  t.not(deleteResponse.status, 200)
 })
 
 test.serial('DELETE /approve/advance rejects deletion when linked from expense report', async (t) => {

--- a/backend/tests/api/advance.ts
+++ b/backend/tests/api/advance.ts
@@ -1,101 +1,242 @@
-import { Advance, AdvanceSimple, AdvanceState } from 'abrechnung-common/types.js'
+import { Base64 } from 'abrechnung-common/utils/encoding.js'
 import test from 'ava'
+import { type Queue } from 'bullmq'
 import { shutdown } from '../../app.js'
+import { closeIntegrationQueue, type IntegrationJobData, setIntegrationQueueForTests } from '../../integrations/queue.js'
 import createAgent, { loginUser } from '../_agent.js'
 
 const agent = await createAgent()
-await loginUser(agent, 'user')
 
-let advance: Partial<Advance> = {
-  name: 'Advance for next trip',
-  reason: 'Traveling is expensive', // biome-ignore lint/suspicious/noExplicitAny: using Types.ObjectId to set IdDocument in backend
-  budget: { amount: 1_000, currency: 'USD' as any }
+let project: Record<string, unknown>
+let category: Record<string, unknown>
+let insurance: Record<string, unknown>
+let restrictedProject: Record<string, unknown>
+
+setIntegrationQueueForTests({
+  add: async () => ({}) as never,
+  close: async () => {},
+  getJob: async () => undefined,
+  getJobSchedulers: async () => [],
+  removeJobScheduler: async () => true,
+  upsertJobScheduler: async () => ({}) as never
+} as unknown as Queue<IntegrationJobData>)
+
+function toIds(entries: Array<{ _id?: string } | string>) {
+  return entries.map((entry) => (typeof entry === 'string' ? entry : entry._id)).filter((entry): entry is string => Boolean(entry))
 }
 
-test.serial('GET /project', async (t) => {
-  const res = await agent.get('/project')
-  advance.project = res.body.data[0]
-  if (res.status === 200) {
-    t.pass()
-  } else {
-    console.log(res.body)
+async function getAdminUser(username: string) {
+  await loginUser(agent, 'admin')
+  const response = await agent.get('/admin/user').query({ filterJSON: Base64.encode(JSON.stringify({ 'fk.ldapauth': username })) })
+  return response.body.data[0] as {
+    _id: string
+    access: Record<string, boolean>
+    email: string
+    projects: { assigned: Array<{ _id: string }>; supervised: Array<{ _id: string }> }
   }
-})
+}
 
-test.serial('POST /advance/appliedFor', async (t) => {
-  const res = await agent.post('/advance/appliedFor').send(advance)
-  advance = res.body.result
-  if (res.status === 200) {
-    t.pass()
-  } else {
-    console.log(res.body)
-  }
-})
-
-test.serial('GET /advance', async (t) => {
-  t.plan(2)
-  const res = await agent.get('/advance')
-  if (res.status === 200) {
-    t.pass()
-  } else {
-    console.log(res.body)
-  }
-  for (const gotAdvance of res.body.data as AdvanceSimple[]) {
-    if (advance._id === gotAdvance._id) {
-      t.pass()
-      break
-    }
-  }
-})
-
-// APPROVE
-
-test.serial('POST /approve/advance/approved', async (t) => {
-  await loginUser(agent, 'advance')
-  t.plan(3)
-  const bookingRemark = 'My Booking Remark'
-  const res = await agent.post('/approve/advance/approved').send({ _id: advance._id, bookingRemark })
-  if (res.status === 200) {
-    t.pass()
-  } else {
-    console.log(res.body)
-  }
-  t.is((res.body.result as Advance).state, AdvanceState.APPROVED)
-  t.is((res.body.result as Advance).bookingRemark, bookingRemark)
-})
-
-// REPORT
-
-test.serial('GET /advance/report', async (t) => {
+async function createAppliedAdvance(name: string, advanceProject = project) {
   await loginUser(agent, 'user')
-  const res = await agent.get('/advance/report').query({ _id: advance._id })
-  if (res.status === 200) {
-    t.pass()
-  } else {
-    console.log(res.body)
-  }
-})
+  const response = await agent
+    .post('/advance/appliedFor')
+    .send({ name, reason: `${name} reason`, budget: { amount: 1_000, currency: 'USD' }, project: advanceProject })
+  return response
+}
 
-// BOOK
-
-test.serial('POST /book/advance/booked', async (t) => {
+async function approveAdvance(_id: string) {
   await loginUser(agent, 'advance')
-  t.plan(2)
-  const res = await agent.post('/book/advance/booked').send([advance._id])
-  if (res.status === 200) {
-    t.pass()
-  } else {
-    console.log(res.body)
-  }
-  t.is(res.body.result[0].status, 'fulfilled')
+  return await agent.post('/approve/advance/approved').send({ _id })
+}
+
+async function createApprovedAdvanceByApprover(name: string, owner: string, advanceProject = project) {
+  await loginUser(agent, 'advance')
+  return await agent
+    .post('/approve/advance/approved')
+    .send({ name, owner, project: advanceProject, reason: `${name} reason`, budget: { amount: 250, currency: 'EUR' } })
+}
+
+async function deleteApprovedAdvance(_id: string) {
+  await loginUser(agent, 'advance')
+  return await agent.delete('/approve/advance').query({ _id })
+}
+
+test.serial('load shared fixtures', async (t) => {
+  await loginUser(agent, 'user')
+  const [projectResponse, categoryResponse, insuranceResponse] = await Promise.all([
+    agent.get('/project'),
+    agent.get('/category'),
+    agent.get('/healthInsurance')
+  ])
+
+  t.is(projectResponse.status, 200)
+  t.is(categoryResponse.status, 200)
+  t.is(insuranceResponse.status, 200)
+
+  project = projectResponse.body.data[0]
+  category = categoryResponse.body.data[0]
+  insurance = insuranceResponse.body.data[0]
 })
 
-test.serial('DELETE /advance 40X', async (t) => {
+test.serial('DELETE /approve/advance deletes approved owner advance and mails owner plus project booker', async (t) => {
+  const reportName = 'Delete me as approver'
+  const createdResponse = await createAppliedAdvance(reportName)
+  t.is(createdResponse.status, 200)
+  const advance = createdResponse.body.result as { _id: string }
+
+  const approvedResponse = await approveAdvance(advance._id)
+  t.is(approvedResponse.status, 200)
+
+  const deleteResponse = await deleteApprovedAdvance(advance._id)
+  t.is(deleteResponse.status, 200)
+  t.is(deleteResponse.body.deletedCount, 1)
+
+  await loginUser(agent, 'advance')
+  const getDeletedResponse = await agent.get('/approve/advance').query({ _id: advance._id })
+  t.not(getDeletedResponse.status, 200)
+})
+
+test.serial('DELETE /approve/advance deletes approver-created advance and deduplicates mail recipients', async (t) => {
+  const advanceUser = await getAdminUser('bender')
+  const reportName = 'Approver created advance'
+  const createdResponse = await createApprovedAdvanceByApprover(reportName, advanceUser._id)
+  t.is(createdResponse.status, 200)
+  const advance = createdResponse.body.result as { _id: string }
+
+  const deleteResponse = await deleteApprovedAdvance(advance._id)
+  t.is(deleteResponse.status, 200)
+  t.is(deleteResponse.body.deletedCount, 1)
+})
+
+test.serial('DELETE /approve/advance rejects deletion when linked from expense report', async (t) => {
+  const createdResponse = await createAppliedAdvance('Expense report link')
+  t.is(createdResponse.status, 200)
+  const advance = createdResponse.body.result as { _id: string }
+
+  const approvedResponse = await approveAdvance(advance._id)
+  t.is(approvedResponse.status, 200)
+
   await loginUser(agent, 'user')
-  const res = await agent.delete('/advance').query({ _id: advance._id })
-  t.not(res.status, 200)
+  const reportResponse = await agent
+    .post('/expenseReport/inWork')
+    .send({ name: 'Advance link expense report', project, category, advances: [advance._id] })
+  t.is(reportResponse.status, 200)
+
+  const deleteResponse = await deleteApprovedAdvance(advance._id)
+  t.is(deleteResponse.status, 409)
+})
+
+test.serial('DELETE /approve/advance rejects deletion when linked from health care cost', async (t) => {
+  const createdResponse = await createAppliedAdvance('Health care link')
+  t.is(createdResponse.status, 200)
+  const advance = createdResponse.body.result as { _id: string }
+
+  const approvedResponse = await approveAdvance(advance._id)
+  t.is(approvedResponse.status, 200)
+
+  await loginUser(agent, 'user')
+  const reportResponse = await agent
+    .post('/healthCareCost/inWork')
+    .send({ name: 'Advance link health care cost', patientName: 'Philip J. Fry', project, insurance, advances: [advance._id] })
+  t.is(reportResponse.status, 200)
+
+  const deleteResponse = await deleteApprovedAdvance(advance._id)
+  t.is(deleteResponse.status, 409)
+})
+
+test.serial('DELETE /approve/advance rejects deletion when linked from travel', async (t) => {
+  const createdResponse = await createAppliedAdvance('Travel link')
+  t.is(createdResponse.status, 200)
+  const advance = createdResponse.body.result as { _id: string }
+
+  const approvedResponse = await approveAdvance(advance._id)
+  t.is(approvedResponse.status, 200)
+
+  await loginUser(agent, 'user')
+  const reportResponse = await agent
+    .post('/travel/appliedFor')
+    .send({
+      name: 'Advance link travel',
+      reason: 'Conference travel',
+      project,
+      destinationPlace: { country: { _id: 'DE' }, place: 'Berlin' },
+      startDate: new Date('2024-05-01T00:00:00.000Z'),
+      endDate: new Date('2024-05-03T00:00:00.000Z'),
+      advances: [advance._id]
+    })
+  t.is(reportResponse.status, 200)
+
+  const deleteResponse = await deleteApprovedAdvance(advance._id)
+  t.is(deleteResponse.status, 409)
+})
+
+test.serial('DELETE /approve/advance rejects booked advances', async (t) => {
+  const createdResponse = await createAppliedAdvance('Booked advance')
+  t.is(createdResponse.status, 200)
+  const advance = createdResponse.body.result as { _id: string }
+
+  const approvedResponse = await approveAdvance(advance._id)
+  t.is(approvedResponse.status, 200)
+
+  await loginUser(agent, 'advance')
+  const bookedResponse = await agent.post('/book/advance/booked').send([advance._id])
+  t.is(bookedResponse.status, 200)
+
+  const deleteResponse = await deleteApprovedAdvance(advance._id)
+  t.not(deleteResponse.status, 200)
+})
+
+test.serial('DELETE /approve/advance requires matching project permission', async (t) => {
+  const advanceUser = await getAdminUser('bender')
+
+  await loginUser(agent, 'admin')
+  const createProjectResponse = await agent
+    .post('/admin/project')
+    .send({
+      identifier: `ADV-DELETE-${Date.now()}`,
+      name: 'Restricted advance project',
+      organisation: (project as { organisation: unknown }).organisation,
+      balance: { amount: 0 }
+    })
+  t.is(createProjectResponse.status, 200)
+  restrictedProject = createProjectResponse.body.result
+
+  const createdResponse = await createAppliedAdvance('Restricted project advance', restrictedProject)
+  t.is(createdResponse.status, 200)
+  const advance = createdResponse.body.result as { _id: string }
+
+  await loginUser(agent, 'admin')
+  const allowApproverResponse = await agent
+    .post('/admin/user')
+    .send({
+      _id: advanceUser._id,
+      access: advanceUser.access,
+      projects: {
+        assigned: toIds(advanceUser.projects.assigned),
+        supervised: [...toIds(advanceUser.projects.supervised), (restrictedProject as { _id: string })._id]
+      }
+    })
+  t.is(allowApproverResponse.status, 200)
+
+  const approvedResponse = await approveAdvance(advance._id)
+  t.is(approvedResponse.status, 200)
+
+  await loginUser(agent, 'admin')
+  const restrictApproverResponse = await agent
+    .post('/admin/user')
+    .send({
+      _id: advanceUser._id,
+      access: advanceUser.access,
+      projects: { assigned: toIds(advanceUser.projects.assigned), supervised: [(project as { _id: string })._id] }
+    })
+  t.is(restrictApproverResponse.status, 200)
+
+  const deleteResponse = await deleteApprovedAdvance(advance._id)
+  t.not(deleteResponse.status, 200)
 })
 
 test.serial.after.always('Drop DB Connection', async () => {
+  setIntegrationQueueForTests(undefined)
+  await closeIntegrationQueue()
   await shutdown()
 })

--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -595,6 +595,10 @@
         "paragraph": "Dein Vorschussantrag wurde genehmigt.",
         "subject": "✅ Vorschuss genehmigt"
       },
+      "DELETED": {
+        "paragraph": "Der Vorschuss '{reportName}' für {owner} im Projekt {project} wurde von {deletedBy} gelöscht.",
+        "subject": "🗑️ Vorschuss gelöscht"
+      },
       "REJECTED": {
         "lastParagraph": "{commentator} schrieb: '{comment}'",
         "paragraph": "Dein Vorschussantrag wurde abgelehnt.",

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -595,6 +595,10 @@
         "paragraph": "Your advance request has been approved.",
         "subject": "✅ Advance approved"
       },
+      "DELETED": {
+        "paragraph": "The advance '{reportName}' for {owner} in project {project} was deleted by {deletedBy}.",
+        "subject": "🗑️ Advance deleted"
+      },
       "REJECTED": {
         "lastParagraph": "{commentator} wrote: '{comment}'",
         "paragraph": "Your advance request was rejected.",

--- a/common/locales/es.json
+++ b/common/locales/es.json
@@ -595,6 +595,10 @@
         "paragraph": "Tu solicitud de anticipo ha sido aprobada.",
         "subject": "✅ Anticipo aprobado"
       },
+      "DELETED": {
+        "paragraph": "El anticipo '{reportName}' para {owner} en el proyecto {project} fue eliminado por {deletedBy}.",
+        "subject": "🗑️ Anticipo eliminado"
+      },
       "REJECTED": {
         "lastParagraph": "{commentator} escribió: '{comment}'",
         "paragraph": "Tu solicitud de anticipo ha sido rechazada.",

--- a/common/locales/fr.json
+++ b/common/locales/fr.json
@@ -595,6 +595,10 @@
         "paragraph": "Votre demande d'avance a été approuvée.",
         "subject": "✅ Avance approuvée"
       },
+      "DELETED": {
+        "paragraph": "L'avance '{reportName}' pour {owner} dans le projet {project} a été supprimée par {deletedBy}.",
+        "subject": "🗑️ Avance supprimée"
+      },
       "REJECTED": {
         "lastParagraph": "{commentator} a écrit : '{comment}'",
         "paragraph": "Votre demande d'avance a été refusée.",

--- a/common/locales/kk.json
+++ b/common/locales/kk.json
@@ -595,6 +595,10 @@
         "paragraph": "Сіздің аванс сұранысыңыз мақұлданды.",
         "subject": "✅ Аванс мақұлданды"
       },
+      "DELETED": {
+        "paragraph": "{project} жобасындағы {owner} үшін '{reportName}' авансы {deletedBy} тарапынан жойылды.",
+        "subject": "🗑️ Аванс жойылды"
+      },
       "REJECTED": {
         "lastParagraph": "{commentator} жазды: '{comment}'",
         "paragraph": "Сіздің аванс сұранысыңыз қабылданбаған.",

--- a/common/locales/ru.json
+++ b/common/locales/ru.json
@@ -595,6 +595,10 @@
         "paragraph": "Ваш авансовый запрос был одобрен.",
         "subject": "✅ Аванс одобрен"
       },
+      "DELETED": {
+        "paragraph": "Аванс '{reportName}' для {owner} по проекту {project} был удалён пользователем {deletedBy}.",
+        "subject": "🗑️ Аванс удалён"
+      },
       "REJECTED": {
         "lastParagraph": "{commentator} написал: '{comment}'",
         "paragraph": "Ваш авансовый запрос был отклонён.",

--- a/frontend/src/components/advance/ApprovePage.vue
+++ b/frontend/src/components/advance/ApprovePage.vue
@@ -178,7 +178,7 @@ function resetAndHide() {
 }
 
 function canDeleteAdvance(advance: AdvanceSimple<string>) {
-  return advance.state === AdvanceState.APPROVED && advance.offsetAgainst.length === 0
+  return advance.state === AdvanceState.APPROVED && !advance.receivedOn && advance.offsetAgainst.length === 0
 }
 
 async function approveAdvance(

--- a/frontend/src/components/advance/ApprovePage.vue
+++ b/frontend/src/components/advance/ApprovePage.vue
@@ -5,7 +5,7 @@
       ref="modalComp"
       @afterClose="modalMode === 'view' ? resetModal() : null">
       <template #header="{header}">
-        <h5 class="modal-title">{{header}}</h5>
+        <h5 class="modal-title">{{ header }}</h5>
         <RefStringBadge v-if="modalAdvance.reference" class="ms-2" :number="modalAdvance.reference" type="Advance" />
       </template>
       <div v-if="modalAdvance">
@@ -26,6 +26,13 @@
                     class="btn btn-secondary"
                     @click="isOffsetFormVisible = true">
                     {{ t('labels.addX', {X: t('labels.offsetEntry')}) }}
+                  </button>
+                  <button
+                    v-if="canDeleteAdvance(modalAdvance as AdvanceSimple<string>)"
+                    type="button"
+                    class="btn btn-danger ms-2"
+                    @click="deleteAdvance((modalAdvance as AdvanceSimple<string>)._id)">
+                    {{ t('labels.delete') }}
                   </button>
                 </template>
               </Advance>
@@ -170,6 +177,10 @@ function resetAndHide() {
   hideModal()
 }
 
+function canDeleteAdvance(advance: AdvanceSimple<string>) {
+  return advance.state === AdvanceState.APPROVED && advance.offsetAgainst.length === 0
+}
+
 async function approveAdvance(
   advance: AdvanceSimple,
   decision: 'approved' | 'rejected',
@@ -204,6 +215,17 @@ async function offsetAdvance(advanceId: string, amount: number) {
       offsetAmount.value = 0
       isOffsetFormVisible.value = false
     }
+  }
+}
+
+async function deleteAdvance(_id: string) {
+  modalFormIsLoading.value = true
+  const result = await API.deleter('approve/advance', { _id })
+  modalFormIsLoading.value = false
+  if (result) {
+    advanceList.value?.loadFromServer()
+    approvedAdvanceList.value?.loadFromServer()
+    resetAndHide()
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Approved advances can be deleted by project supervisors when eligible (not historic, not received, no offsets).
* **User Interface**
  * Delete button added to the advance approval modal for eligible records; list views refresh after deletion.
* **Notifications / Localization**
  * Deletion emails sent to relevant stakeholders, grouped by language; new localized templates added (en, de, es, fr, kk, ru).
* **Tests**
  * Expanded integration tests covering deletion success/failure scenarios and permission checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->