### PR TITLE
Feature: magic login auto fill on user creation via web form

### DIFF
--- a/frontend/src/components/settings/elements/UserList.vue
+++ b/frontend/src/components/settings/elements/UserList.vue
@@ -80,7 +80,7 @@
         ref="form$"
         @submit="(form$: any) => postUser(form$.data)"
         @reset="_showForm = false"
-        @mounted="(form$:any) => {form$.el$('fk.genApiKey').on('click', () => {($refs.modal as any).modal.show()})}" />
+        @mounted="setupForm" />
     </div>
     <button v-else type="button" class="btn btn-secondary" @click="showForm()">{{ t('labels.addX', { X: t('labels.user') }) }}</button>
   </div>
@@ -98,6 +98,7 @@ import ListElement from '@/components/elements/ListElement.vue'
 import ModalComponent from '@/components/elements/ModalComponent.vue'
 import APP_LOADER from '@/dataLoader.js'
 import { formatter } from '@/formatter.js'
+import { getSyncedMagicLogin } from './userForm.js'
 
 const { t } = useI18n()
 
@@ -147,6 +148,7 @@ function clickFilter(header: keyof typeof showFilter.value, event?: MouseEvent) 
 
 const userToEdit: Ref<User | undefined> = ref(undefined)
 const _showForm = ref(false)
+const modal = useTemplateRef<{ modal: { show: () => void } }>('modal')
 
 function showForm(user?: User) {
   // biome-ignore lint/suspicious/noExplicitAny: reduce arrays of objects to arrays of _ids for vueform select elements
@@ -179,6 +181,31 @@ async function deleteUser(user: User<string>) {
     loadFromServer()
     APP_LOADER.loadOptional('users')
   }
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: Vueform does not expose the mounted form instance type through its component event
+function setupForm(form$: any) {
+  form$.el$('fk.genApiKey').on('click', () => {
+    modal.value?.modal.show()
+  })
+
+  const magicLoginEnabled = schema.fk?.schema?.magiclogin?.type !== 'hidden'
+  const emailElement = form$.el$('email')
+  const magicLoginElement = form$.el$('fk.magiclogin')
+
+  emailElement.on('change', (email: string | null | undefined, previousEmail: string | null | undefined) => {
+    const magicLogin = getSyncedMagicLogin({
+      email,
+      existingUser: Boolean(userToEdit.value?._id),
+      magicLogin: magicLoginElement.value,
+      magicLoginEnabled,
+      previousEmail
+    })
+
+    if (magicLogin !== magicLoginElement.value) {
+      magicLoginElement.update(magicLogin)
+    }
+  })
 }
 
 const buttons = {

--- a/frontend/src/components/settings/elements/userForm.ts
+++ b/frontend/src/components/settings/elements/userForm.ts
@@ -1,0 +1,15 @@
+interface MagicLoginSyncOptions {
+  email: string | null | undefined
+  existingUser: boolean
+  magicLogin: string | null | undefined
+  magicLoginEnabled: boolean
+  previousEmail: string | null | undefined
+}
+
+export function getSyncedMagicLogin({ email, existingUser, magicLogin, magicLoginEnabled, previousEmail }: MagicLoginSyncOptions) {
+  if (existingUser || !magicLoginEnabled || (magicLogin ?? '') !== (previousEmail ?? '')) {
+    return magicLogin
+  }
+
+  return email
+}

--- a/frontend/tests/userForm.test.ts
+++ b/frontend/tests/userForm.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { getSyncedMagicLogin } from '@/components/settings/elements/userForm.js'
+
+describe('user form magic-login default', () => {
+  it('defaults an empty magic login to the initial email', () => {
+    expect(
+      getSyncedMagicLogin({
+        email: 'user@example.com',
+        existingUser: false,
+        magicLogin: undefined,
+        magicLoginEnabled: true,
+        previousEmail: undefined
+      })
+    ).toBe('user@example.com')
+  })
+
+  it('keeps the magic login synchronized while it matches the previous email', () => {
+    expect(
+      getSyncedMagicLogin({
+        email: 'new@example.com',
+        existingUser: false,
+        magicLogin: 'old@example.com',
+        magicLoginEnabled: true,
+        previousEmail: 'old@example.com'
+      })
+    ).toBe('new@example.com')
+  })
+
+  it.each([
+    ['a custom value', 'login@example.com'],
+    ['a manually cleared value', '']
+  ])('preserves %s', (_description, magicLogin) => {
+    expect(
+      getSyncedMagicLogin({
+        email: 'new@example.com',
+        existingUser: false,
+        magicLogin,
+        magicLoginEnabled: true,
+        previousEmail: 'old@example.com'
+      })
+    ).toBe(magicLogin)
+  })
+
+  it('preserves the magic login for existing users', () => {
+    expect(
+      getSyncedMagicLogin({
+        email: 'new@example.com',
+        existingUser: true,
+        magicLogin: 'old@example.com',
+        magicLoginEnabled: true,
+        previousEmail: 'old@example.com'
+      })
+    ).toBe('old@example.com')
+  })
+
+  it('does not populate magic login when the strategy is disabled', () => {
+    expect(
+      getSyncedMagicLogin({
+        email: 'user@example.com',
+        existingUser: false,
+        magicLogin: undefined,
+        magicLoginEnabled: false,
+        previousEmail: undefined
+      })
+    ).toBeUndefined()
+  })
+})


### PR DESCRIPTION
implements #558 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Magic login values now synchronize with email changes when appropriate.
  * Added an API key modal trigger within the user settings form.
  * Existing custom or manually cleared magic login values are preserved.

* **Bug Fixes**
  * Magic login is no longer populated when the feature is disabled.

* **Tests**
  * Added coverage for magic login synchronization and preservation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->