### PR TITLE
feat: implement withdraw approval functionality for advances and travels

### DIFF
--- a/backend/controller/advanceController.ts
+++ b/backend/controller/advanceController.ts
@@ -1,7 +1,7 @@
 import { Readable } from 'node:stream'
 import { Body, Delete, Get, Post, Produces, Queries, Query, Request, Route, Security, Tags } from '@tsoa/runtime'
 import { AdvanceState, Advance as IAdvance, IdDocument, idDocumentToId, State } from 'abrechnung-common/types.js'
-import { QueryFilter, Types } from 'mongoose'
+import { Document, model, QueryFilter, Types } from 'mongoose'
 import { BACKEND_CACHE } from '../db.js'
 import { createOperationServices } from '../factory.js'
 import { checkIfUserIsProjectSupervisor, setAdvanceBalance } from '../helper.js'
@@ -11,6 +11,7 @@ import { sendAdvanceDeletionNotification } from '../integrations/notifications/s
 import Advance, { AdvanceDoc } from '../models/advance.js'
 import ExpenseReport from '../models/expenseReport.js'
 import HealthCareCost from '../models/healthCareCost.js'
+import ReportUsage from '../models/reportUsage.js'
 import Travel from '../models/travel.js'
 import { Controller, checkOwner, GetterQuery } from './controller.js'
 import { AuthorizationError, NotFoundError } from './error.js'
@@ -23,6 +24,22 @@ interface AdvanceApplication {
   budget: MoneyPost
   reason: string
   comment?: string
+}
+
+async function unlinkAdvanceFromIncompleteReports(advanceId: Types.ObjectId) {
+  const filter = { advances: advanceId, historic: false, state: { $lt: State.BOOKABLE } }
+  const reports: Document[] = []
+  reports.push(...(await model('Travel').find(filter)))
+  reports.push(...(await model('ExpenseReport').find(filter)))
+  reports.push(...(await model('HealthCareCost').find(filter)))
+  for (const report of reports) {
+    const advances = report.get('advances') as IdDocument<Types.ObjectId>[]
+    report.set(
+      'advances',
+      advances.filter((advance) => !idDocumentToId(advance).equals(advanceId))
+    )
+    await report.save()
+  }
 }
 
 @Tags('Advance')
@@ -213,6 +230,36 @@ export class AdvanceApproveController extends Controller {
         return false
       }
     })
+  }
+
+  @Post('withdrawApproval')
+  public async withdrawApproval(@Body() requestBody: { _id: string; comment?: string }, @Request() request: AuthenticatedExpressRequest) {
+    const extendedBody = Object.assign(requestBody, { state: AdvanceState.REJECTED, editor: request.user._id, bookingRemark: null })
+
+    const result = await this.setter(Advance, {
+      requestBody: extendedBody,
+      allowNew: false,
+      async checkOldObject(oldObject: AdvanceDoc) {
+        if (
+          oldObject.state !== AdvanceState.APPROVED ||
+          oldObject.receivedOn ||
+          oldObject.offsetAgainst.length > 0 ||
+          !checkIfUserIsProjectSupervisor(request.user, oldObject.project._id)
+        ) {
+          return false
+        }
+        await unlinkAdvanceFromIncompleteReports(oldObject._id)
+        await oldObject.saveToHistory()
+        oldObject.log[AdvanceState.REJECTED] = undefined
+        oldObject.log[AdvanceState.APPROVED] = undefined
+        oldObject.markModified('log')
+        return true
+      }
+    })
+
+    await ReportUsage.deleteOne({ reportId: result.result._id })
+    await emitIntegrationEvent({ type: 'report.approval_withdrawn', report: result.result })
+    return result
   }
 
   @Post('rejected')

--- a/backend/controller/travelController.ts
+++ b/backend/controller/travelController.ts
@@ -17,6 +17,7 @@ import { createOperationServices } from '../factory.js'
 import { checkIfUserIsProjectSupervisor, documentFileHandler, fileHandler } from '../helper.js'
 import i18n from '../i18n.js'
 import { emitIntegrationEvent } from '../integrations/dispatcher.js'
+import ApprovedTravel from '../models/approvedTravel.js'
 import Travel, { TravelDoc } from '../models/travel.js'
 import User from '../models/user.js'
 import { Controller, checkOwner, GetterQuery, SetterBody } from './controller.js'
@@ -337,6 +338,30 @@ export class TravelApproveController extends Controller {
         return false
       }
     })
+  }
+
+  @Post('withdrawApproval')
+  public async withdrawApproval(@Body() requestBody: { _id: string; comment?: string }, @Request() request: AuthenticatedExpressRequest) {
+    const extendedBody = Object.assign(requestBody, { state: TravelState.REJECTED, editor: request.user._id })
+
+    const result = await this.setter(Travel, {
+      requestBody: extendedBody,
+      allowNew: false,
+      async checkOldObject(oldObject: TravelDoc) {
+        if (oldObject.state !== TravelState.APPROVED || !checkIfUserIsProjectSupervisor(request.user, oldObject.project._id)) {
+          return false
+        }
+        await oldObject.saveToHistory()
+        oldObject.log[TravelState.REJECTED] = undefined
+        oldObject.log[TravelState.APPROVED] = undefined
+        oldObject.markModified('log')
+        return true
+      }
+    })
+
+    await ApprovedTravel.deleteOne({ reportId: result.result._id })
+    await emitIntegrationEvent({ type: 'report.approval_withdrawn', report: result.result })
+    return result
   }
 
   @Post('rejected')

--- a/backend/integrations/events.ts
+++ b/backend/integrations/events.ts
@@ -9,6 +9,7 @@ export type IntegrationEvent =
   | { type: 'report.submitted'; report: ReportEventTarget }
   | { type: 'report.review_requested'; report: ReportEventTarget }
   | { type: 'report.rejected'; report: ReportEventTarget }
+  | { type: 'report.approval_withdrawn'; report: ReportEventTarget }
   | { type: 'report.back_to_in_work'; report: ReportEventTarget }
   | { type: 'report.review_completed'; report: ReviewableReportTarget }
   | { type: 'travel.directly_approved'; report: TravelEventTarget }

--- a/backend/integrations/notifications/status.ts
+++ b/backend/integrations/notifications/status.ts
@@ -27,12 +27,14 @@ import { type IntegrationEventHandlerMap } from '../events.js'
 import { Integration } from '../integration.js'
 import { enqueueMail, type MailRecipient } from './email.js'
 import { enqueuePushNotification } from './push.js'
+import { getOwnerReportRoute } from './statusLinks.js'
 
 class StatusNotificationIntegration extends Integration {
   override readonly events: Partial<IntegrationEventHandlerMap> = {
     'report.submitted': async ({ report }) => await sendStatusNotification(report),
     'report.review_requested': async ({ report }) => await sendStatusNotification(report),
     'report.rejected': async ({ report }) => await sendStatusNotification(report),
+    'report.approval_withdrawn': async ({ report }) => await sendStatusNotification(report, 'APPROVAL_WITHDRAWN', true),
     'report.back_to_in_work': async ({ report }) => await sendStatusNotification(report, 'BACK_TO_IN_WORK'),
     'report.review_completed': async ({ report }) => await sendStatusNotification(report),
     'travel.approved': async ({ report }) => await sendStatusNotification(report),
@@ -100,7 +102,8 @@ export async function sendAdvanceDeletionNotification(
 
 export async function sendStatusNotification(
   report: TravelSimple | ExpenseReportSimple | HealthCareCostSimple | Advance,
-  textState?: string
+  textState?: string,
+  notifyOwner = false
 ) {
   let recipients = []
   let reportType: ReportType
@@ -123,7 +126,10 @@ export async function sendStatusNotification(
   const supervisedProjectsFilter = { $or: [{ 'projects.supervised': [] }, { 'projects.supervised': report.project._id }] }
   const userFilter: QueryFilter<IUser<Types.ObjectId, mongo.Binary>> = {}
 
-  if (report.state === State.APPLIED_FOR) {
+  if (notifyOwner) {
+    userFilter._id = report.owner._id
+    button.link = `${ENV.VITE_FRONTEND_URL}${getOwnerReportRoute(reportType, report._id, report.state)}`
+  } else if (report.state === State.APPLIED_FOR) {
     userFilter[`access.approve/${reportType}`] = true
     Object.assign(userFilter, supervisedProjectsFilter)
     button.link = `${ENV.VITE_FRONTEND_URL}/approve/${reportType}/${report._id}`
@@ -133,8 +139,7 @@ export async function sendStatusNotification(
     button.link = `${ENV.VITE_FRONTEND_URL}/examine/${reportType}/${report._id}`
   } else {
     userFilter._id = report.owner._id
-    button.link =
-      report.state === State.REJECTED ? `${ENV.VITE_FRONTEND_URL}/${reportType}` : `${ENV.VITE_FRONTEND_URL}/${reportType}/${report._id}`
+    button.link = `${ENV.VITE_FRONTEND_URL}${getOwnerReportRoute(reportType, report._id, report.state)}`
   }
 
   recipients = await User.find(userFilter).lean()

--- a/backend/integrations/notifications/statusLinks.ts
+++ b/backend/integrations/notifications/statusLinks.ts
@@ -1,0 +1,11 @@
+import { type _id, type AnyState, type ReportType, State } from 'abrechnung-common/types.js'
+
+export function getOwnerReportRoute(reportType: ReportType, reportId: _id, state: AnyState) {
+  if (state === State.REJECTED) {
+    if (reportType === 'travel') return `/user/travel/${reportId}`
+    if (reportType === 'advance') return `/advance/${reportId}`
+    return `/${reportType}`
+  }
+
+  return `/${reportType}/${reportId}`
+}

--- a/backend/tests/api/advance.ts
+++ b/backend/tests/api/advance.ts
@@ -1,3 +1,4 @@
+import { AdvanceState } from 'abrechnung-common/types.js'
 import { Base64 } from 'abrechnung-common/utils/encoding.js'
 import test from 'ava'
 import { type Queue } from 'bullmq'
@@ -59,6 +60,11 @@ async function createApprovedAdvanceByApprover(name: string, owner: string, adva
 async function deleteApprovedAdvance(_id: string) {
   await loginUser(agent, 'advance')
   return await agent.delete('/approve/advance').query({ _id })
+}
+
+async function withdrawAdvanceApproval(_id: string, comment?: string) {
+  await loginUser(agent, 'advance')
+  return await agent.post('/approve/advance/withdrawApproval').send({ _id, comment })
 }
 
 async function confirmAdvanceReceipt(_id: string, receivedOn = new Date('2024-05-05T00:00:00.000Z')) {
@@ -126,9 +132,12 @@ test.serial('DELETE /approve/advance rejects deletion after receipt was confirme
 
   const deleteResponse = await deleteApprovedAdvance(advance._id)
   t.not(deleteResponse.status, 200)
+
+  const withdrawResponse = await withdrawAdvanceApproval(advance._id)
+  t.not(withdrawResponse.status, 200)
 })
 
-test.serial('DELETE /approve/advance rejects deletion when linked from expense report', async (t) => {
+test.serial('POST /approve/advance/withdrawApproval rejects the approval and unlinks unfinished reports', async (t) => {
   const createdResponse = await createAppliedAdvance('Expense report link')
   t.is(createdResponse.status, 200)
   const advance = createdResponse.body.result as { _id: string }
@@ -144,6 +153,36 @@ test.serial('DELETE /approve/advance rejects deletion when linked from expense r
 
   const deleteResponse = await deleteApprovedAdvance(advance._id)
   t.is(deleteResponse.status, 409)
+
+  const comment = 'Approval is no longer valid'
+  const withdrawResponse = await withdrawAdvanceApproval(advance._id, comment)
+  t.is(withdrawResponse.status, 200)
+  const withdrawnAdvance = withdrawResponse.body.result
+  t.is(withdrawnAdvance.state, AdvanceState.REJECTED)
+  t.falsy(withdrawnAdvance.log[AdvanceState.APPROVED])
+  t.truthy(withdrawnAdvance.log[AdvanceState.REJECTED])
+  t.like(withdrawnAdvance.comments.at(-1), { text: comment, toState: AdvanceState.REJECTED })
+  t.is(withdrawnAdvance.history.length, 2)
+
+  await loginUser(agent, 'user')
+  const unlinkedReportResponse = await agent.get('/expenseReport').query({ _id: reportResponse.body.result._id })
+  t.is(unlinkedReportResponse.status, 200)
+  t.deepEqual(unlinkedReportResponse.body.data.advances, [])
+
+  const resubmitResponse = await agent
+    .post('/advance/appliedFor')
+    .send({
+      _id: advance._id,
+      name: withdrawnAdvance.name,
+      reason: withdrawnAdvance.reason,
+      budget: withdrawnAdvance.budget,
+      project: withdrawnAdvance.project
+    })
+  t.is(resubmitResponse.status, 200)
+  const reapproveResponse = await approveAdvance(advance._id)
+  t.is(reapproveResponse.status, 200)
+  t.truthy(reapproveResponse.body.result.log[AdvanceState.APPROVED])
+  t.is(reapproveResponse.body.result.history.length, 3)
 })
 
 test.serial('DELETE /approve/advance rejects deletion when linked from health care cost', async (t) => {
@@ -162,6 +201,12 @@ test.serial('DELETE /approve/advance rejects deletion when linked from health ca
 
   const deleteResponse = await deleteApprovedAdvance(advance._id)
   t.is(deleteResponse.status, 409)
+
+  const withdrawResponse = await withdrawAdvanceApproval(advance._id)
+  t.is(withdrawResponse.status, 200)
+  await loginUser(agent, 'user')
+  const unlinkedReportResponse = await agent.get('/healthCareCost').query({ _id: reportResponse.body.result._id })
+  t.deepEqual(unlinkedReportResponse.body.data.advances, [])
 })
 
 test.serial('DELETE /approve/advance rejects deletion when linked from travel', async (t) => {
@@ -188,6 +233,12 @@ test.serial('DELETE /approve/advance rejects deletion when linked from travel', 
 
   const deleteResponse = await deleteApprovedAdvance(advance._id)
   t.is(deleteResponse.status, 409)
+
+  const withdrawResponse = await withdrawAdvanceApproval(advance._id)
+  t.is(withdrawResponse.status, 200)
+  await loginUser(agent, 'user')
+  const unlinkedReportResponse = await agent.get('/travel').query({ _id: reportResponse.body.result._id })
+  t.deepEqual(unlinkedReportResponse.body.data.advances, [])
 })
 
 test.serial('DELETE /approve/advance rejects booked advances', async (t) => {
@@ -204,6 +255,24 @@ test.serial('DELETE /approve/advance rejects booked advances', async (t) => {
 
   const deleteResponse = await deleteApprovedAdvance(advance._id)
   t.not(deleteResponse.status, 200)
+
+  const withdrawResponse = await withdrawAdvanceApproval(advance._id)
+  t.not(withdrawResponse.status, 200)
+})
+
+test.serial('POST /approve/advance/withdrawApproval rejects manually offset advances', async (t) => {
+  const createdResponse = await createAppliedAdvance('Manually offset advance')
+  const advance = createdResponse.body.result as { _id: string }
+  const approvedResponse = await approveAdvance(advance._id)
+  t.is(approvedResponse.status, 200)
+
+  const offsetResponse = await agent
+    .post('/approve/advance/offset')
+    .send({ advanceId: advance._id, amount: 10, subject: 'Manual correction' })
+  t.is(offsetResponse.status, 200)
+
+  const withdrawResponse = await withdrawAdvanceApproval(advance._id)
+  t.not(withdrawResponse.status, 200)
 })
 
 test.serial('DELETE /approve/advance requires matching project permission', async (t) => {
@@ -253,6 +322,9 @@ test.serial('DELETE /approve/advance requires matching project permission', asyn
 
   const deleteResponse = await deleteApprovedAdvance(advance._id)
   t.not(deleteResponse.status, 200)
+
+  const withdrawResponse = await withdrawAdvanceApproval(advance._id)
+  t.not(withdrawResponse.status, 200)
 })
 
 test.serial.after.always('Drop DB Connection', async () => {

--- a/backend/tests/api/travel.ts
+++ b/backend/tests/api/travel.ts
@@ -507,6 +507,12 @@ test.serial('POST /examine/travel/reviewCompleted', async (t) => {
   t.is((res.body.result as Travel).comments.length, 2)
 })
 
+test.serial('POST /approve/travel/withdrawApproval rejects review-completed travel', async (t) => {
+  await loginUser(agent, 'travel')
+  const res = await agent.post('/approve/travel/withdrawApproval').send({ _id: travel._id })
+  t.not(res.status, 200)
+})
+
 // REPORT
 
 test.serial('GET /travel/report', async (t) => {
@@ -533,6 +539,55 @@ test.serial('POST /book/travel/booked', async (t) => {
     t.fail()
   }
   t.is(res.body.result[0].status, 'fulfilled')
+})
+
+test.serial('POST /approve/travel/withdrawApproval rejects booked travel', async (t) => {
+  const res = await agent.post('/approve/travel/withdrawApproval').send({ _id: travel._id })
+  t.not(res.status, 200)
+})
+
+test.serial('POST /approve/travel/withdrawApproval rejects approval and allows fresh reapproval', async (t) => {
+  await loginUser(agent, 'user')
+  const application = {
+    name: 'Withdrawable travel',
+    reason: 'Plans may change',
+    project: travel.project,
+    destinationPlace: { country: { _id: 'DE' }, place: 'Berlin' },
+    startDate: new Date('2030-05-01T00:00:00.000Z'),
+    endDate: new Date('2030-05-02T00:00:00.000Z'),
+    advances: []
+  }
+  const createdResponse = await agent.post('/travel/appliedFor').send(application)
+  t.is(createdResponse.status, 200)
+  const createdTravel = createdResponse.body.result as Travel
+
+  await loginUser(agent, 'travel')
+  const approvedResponse = await agent.post('/approve/travel/approved').send({ _id: createdTravel._id })
+  t.is(approvedResponse.status, 200)
+
+  const comment = 'The authorization was revoked'
+  const withdrawResponse = await agent.post('/approve/travel/withdrawApproval').send({ _id: createdTravel._id, comment })
+  t.is(withdrawResponse.status, 200)
+  const withdrawnTravel = withdrawResponse.body.result as Travel
+  t.is(withdrawnTravel.state, TravelState.REJECTED)
+  t.falsy(withdrawnTravel.log[TravelState.APPROVED])
+  t.truthy(withdrawnTravel.log[TravelState.REJECTED])
+  t.like(withdrawnTravel.comments.at(-1), { text: comment, toState: TravelState.REJECTED })
+  t.is(withdrawnTravel.history.length, 2)
+
+  const approvedTravelsResponse = await agent.get('/approvedTravel')
+  t.is(approvedTravelsResponse.status, 200)
+  t.false(approvedTravelsResponse.body.data.some((approvedTravel: { reportId: string }) => approvedTravel.reportId === createdTravel._id))
+
+  await loginUser(agent, 'user')
+  const resubmitResponse = await agent.post('/travel/appliedFor').send({ ...application, _id: createdTravel._id })
+  t.is(resubmitResponse.status, 200)
+
+  await loginUser(agent, 'travel')
+  const reapproveResponse = await agent.post('/approve/travel/approved').send({ _id: createdTravel._id })
+  t.is(reapproveResponse.status, 200)
+  t.truthy(reapproveResponse.body.result.log[TravelState.APPROVED])
+  t.is(reapproveResponse.body.result.history.length, 3)
 })
 
 // test.after.always('DELETE /travel', async (t) => {

--- a/backend/tests/calculation/advance.ts
+++ b/backend/tests/calculation/advance.ts
@@ -60,6 +60,13 @@ test.serial('correct balance after report review completed', async (t) => {
   t.is(_advance.offsetAgainst[0].subject, expenseReport.name)
 })
 
+test.serial('cannot withdraw an advance used by a review-completed report', async (t) => {
+  await loginUser(agent, 'advance')
+  const res = await agent.post('/approve/advance/withdrawApproval').send({ _id: advance._id })
+  t.not(res.status, 200)
+  await loginUser(agent, 'expenseReport')
+})
+
 test.serial('correct balance after report booked', async (t) => {
   await agent.post('/book/expenseReport/booked').send([expenseReport._id])
 

--- a/backend/tests/integrations/events.ts
+++ b/backend/tests/integrations/events.ts
@@ -26,7 +26,7 @@ function createTravelReport(overrides: Record<string, unknown> = {}) {
 function createIntegrations() {
   const calls = {
     webhooks: [] as IntegrationReport[],
-    notifications: [] as Array<{ report: unknown; textState?: string }>,
+    notifications: [] as Array<{ report: unknown; textState?: string; notifyOwner?: boolean }>,
     reportMails: [] as IntegrationReport[],
     a1: [] as IntegrationReport[]
   }
@@ -73,6 +73,9 @@ function createIntegrations() {
         },
         'report.rejected': async (event) => {
           calls.notifications.push({ report: event.report, textState: undefined })
+        },
+        'report.approval_withdrawn': async (event) => {
+          calls.notifications.push({ report: event.report, textState: 'APPROVAL_WITHDRAWN', notifyOwner: true })
         },
         'report.back_to_in_work': async (event) => {
           calls.notifications.push({ report: event.report, textState: 'BACK_TO_IN_WORK' })
@@ -136,6 +139,17 @@ test('report.review_completed fans out to report outbound integrations', async (
   t.deepEqual(calls.webhooks, [report])
   t.deepEqual(calls.notifications, [{ report, textState: undefined }])
   t.deepEqual(calls.reportMails, [report])
+})
+
+test('report.approval_withdrawn only triggers an owner notification', async (t) => {
+  const report = createReport()
+  const { calls, integrations } = createIntegrations()
+
+  await emitIntegrationEvent({ type: 'report.approval_withdrawn', report }, integrations)
+
+  t.deepEqual(calls.webhooks, [])
+  t.deepEqual(calls.notifications, [{ report, textState: 'APPROVAL_WITHDRAWN', notifyOwner: true }])
+  t.deepEqual(calls.reportMails, [])
 })
 
 test('travel.back_to_approved only triggers notification with custom state label', async (t) => {

--- a/backend/tests/integrations/status.ts
+++ b/backend/tests/integrations/status.ts
@@ -1,0 +1,23 @@
+import { AdvanceState, ExpenseReportState, TravelState } from 'abrechnung-common/types.js'
+import test from 'ava'
+import { Types } from 'mongoose'
+import { getOwnerReportRoute } from '../../integrations/notifications/statusLinks.js'
+
+test('rejected travel owner notifications link to the HomePage travel modal', (t) => {
+  const reportId = new Types.ObjectId()
+
+  t.is(getOwnerReportRoute('travel', reportId, TravelState.REJECTED), `/user/travel/${reportId}`)
+})
+
+test('rejected advance owner notifications link to the existing HomePage advance route', (t) => {
+  const reportId = new Types.ObjectId()
+
+  t.is(getOwnerReportRoute('advance', reportId, AdvanceState.REJECTED), `/advance/${reportId}`)
+})
+
+test('non-rejected reports keep their detail routes', (t) => {
+  const reportId = new Types.ObjectId()
+
+  t.is(getOwnerReportRoute('travel', reportId, TravelState.APPROVED), `/travel/${reportId}`)
+  t.is(getOwnerReportRoute('expenseReport', reportId, ExpenseReportState.REVIEW_COMPLETED), `/expenseReport/${reportId}`)
+})

--- a/common/locales/de.json
+++ b/common/locales/de.json
@@ -25,6 +25,7 @@
     "areYouSureDelete": "Bist du dir sicher, dass du das löschen willst? Dies kann NICHT rückgängig gemacht werden!",
     "areYouSureEdit": "Bist du dir sicher, dass du das bearbeiten willst?",
     "areYouSureMerge": "Bist du dir sicher, dass du diese Benutzer zusammenführen willst? Das kann nicht rückgängig gemacht werden.",
+    "areYouSureWithdrawApproval": "Bist du dir sicher, dass du diese Genehmigung zurückziehen möchtest?",
     "conflict": "Konflikt!",
     "countryChangeBetweenStages": "Länderwechsel zwischen aufeinanderfolgenden Etappen",
     "departureAndArrivalOnDifferentDaysX": "Bist du sicher, dass du über mehrere Tage im '{X}' saßt?",
@@ -595,6 +596,7 @@
     "weekly": "Wöchentlich",
     "white": "Weiß",
     "width": "Breite",
+    "withdrawApproval": "Genehmigung zurückziehen",
     "XDetails": "{X}details"
   },
   "languages": {
@@ -622,6 +624,11 @@
         "lastParagraph": "{commentator} schrieb: '{comment}'",
         "paragraph": "Ein neuer Vorschussantrag von {owner} kam gerade rein.",
         "subject": "🆕 Neue Vorschussantrag"
+      },
+      "APPROVAL_WITHDRAWN": {
+        "lastParagraph": "{commentator} schrieb: '{comment}'",
+        "paragraph": "Die Genehmigung deines Vorschusses wurde zurückgezogen.",
+        "subject": "↩️ Vorschussgenehmigung zurückgezogen"
       },
       "APPROVED": {
         "confirmationLine": "Sobald du das Geld erhalten hast, kannst du das [hier]({- confirmLink}) bestätigen.",
@@ -722,6 +729,11 @@
         "lastParagraph": "{commentator} schrieb: '{comment}'",
         "paragraph": "Ein neuer Reiseantrag von {owner} kam gerade rein.",
         "subject": "🆕 Neue Reise"
+      },
+      "APPROVAL_WITHDRAWN": {
+        "lastParagraph": "{commentator} schrieb: '{comment}'",
+        "paragraph": "Die Genehmigung deiner Reise wurde zurückgezogen.",
+        "subject": "↩️ Reisegenehmigung zurückgezogen"
       },
       "APPROVED": {
         "lastParagraph": "{commentator} schrieb: '{comment}'",

--- a/common/locales/en.json
+++ b/common/locales/en.json
@@ -25,6 +25,7 @@
     "areYouSureDelete": "Are you sure you want to delete this? This cannot be undone!",
     "areYouSureEdit": "Are you sure you want to edit this?",
     "areYouSureMerge": "Are you sure you want to merge these users? This cannot be undone.",
+    "areYouSureWithdrawApproval": "Are you sure you want to withdraw this approval?",
     "conflict": "Conflict!",
     "countryChangeBetweenStages": "Country change between consecutive stages",
     "departureAndArrivalOnDifferentDaysX": "Are you sure you were sitting in '{X}' for several days?",
@@ -595,6 +596,7 @@
     "weekly": "Weekly",
     "white": "White",
     "width": "Width",
+    "withdrawApproval": "Withdraw approval",
     "XDetails": "{X} details"
   },
   "languages": {
@@ -622,6 +624,11 @@
         "lastParagraph": "{commentator} wrote: '{comment}'",
         "paragraph": "A new advance request from {owner} just came in.",
         "subject": "🆕 New advance request"
+      },
+      "APPROVAL_WITHDRAWN": {
+        "lastParagraph": "{commentator} wrote: '{comment}'",
+        "paragraph": "The approval of your advance was withdrawn.",
+        "subject": "↩️ Advance approval withdrawn"
       },
       "APPROVED": {
         "confirmationLine": "Once you have received the money, you can confirm it [here]({- confirmLink}).",
@@ -722,6 +729,11 @@
         "lastParagraph": "{commentator} wrote: '{comment}'",
         "paragraph": "A new travel application from {owner} just came in.",
         "subject": "🆕 New Travel"
+      },
+      "APPROVAL_WITHDRAWN": {
+        "lastParagraph": "{commentator} wrote: '{comment}'",
+        "paragraph": "The approval of your travel was withdrawn.",
+        "subject": "↩️ Travel approval withdrawn"
       },
       "APPROVED": {
         "lastParagraph": "{commentator} wrote: '{comment}'",

--- a/common/locales/es.json
+++ b/common/locales/es.json
@@ -25,6 +25,7 @@
     "areYouSureDelete": "¿Estás seguro de que quieres eliminar esto? ¡Esto no se puede deshacer!",
     "areYouSureEdit": "¿Estás seguro de que quieres editar esto?",
     "areYouSureMerge": "¿Estás seguro de que quieres fusionar estos usuarios? Esto no se puede deshacer.",
+    "areYouSureWithdrawApproval": "¿Estás seguro de que quieres retirar esta aprobación?",
     "conflict": "¡Conflicto!",
     "countryChangeBetweenStages": "Cambio de país entre etapas consecutivas",
     "departureAndArrivalOnDifferentDaysX": "¿Estás seguro de que estuviste en \"{X}\" durante varios días?",
@@ -595,6 +596,7 @@
     "weekly": "Semanal",
     "white": "Blanco",
     "width": "Ancho",
+    "withdrawApproval": "Retirar aprobación",
     "XDetails": "Detalles de {X}"
   },
   "languages": {
@@ -622,6 +624,11 @@
         "lastParagraph": "{commentator} escribió: '{comment}'",
         "paragraph": "Un nuevo solicitud de anticipo de {owner} acaba de llegar.",
         "subject": "🆕 Nueva solicitud de anticipo"
+      },
+      "APPROVAL_WITHDRAWN": {
+        "lastParagraph": "{commentator} escribió: '{comment}'",
+        "paragraph": "Se ha retirado la aprobación de tu anticipo.",
+        "subject": "↩️ Aprobación del anticipo retirada"
       },
       "APPROVED": {
         "confirmationLine": "Una vez que hayas recibido el dinero, puedes confirmarlo [aquí]({- confirmLink}).",
@@ -722,6 +729,11 @@
         "lastParagraph": "{commentator} escribió: '{comment}'",
         "paragraph": "Acaba de llegar una nueva solicitud de viaje de {owner}.",
         "subject": "🆕 Nuevo viaje"
+      },
+      "APPROVAL_WITHDRAWN": {
+        "lastParagraph": "{commentator} escribió: '{comment}'",
+        "paragraph": "Se ha retirado la aprobación de tu viaje.",
+        "subject": "↩️ Aprobación del viaje retirada"
       },
       "APPROVED": {
         "lastParagraph": "{commentator} escribió: '{comment}'",

--- a/common/locales/fr.json
+++ b/common/locales/fr.json
@@ -25,6 +25,7 @@
     "areYouSureDelete": "Êtes-vous sûr de vouloir supprimer cela ? Cela ne peut PAS être annulé !",
     "areYouSureEdit": "Êtes-vous sûr de vouloir éditer cela ?",
     "areYouSureMerge": "Êtes-vous sûr de vouloir fusionner ces utilisateurs ? Cela ne peut pas être annulé.",
+    "areYouSureWithdrawApproval": "Êtes-vous sûr de vouloir retirer cette approbation ?",
     "conflict": "Conflit!",
     "countryChangeBetweenStages": "Changement de pays entre des étapes consécutives",
     "departureAndArrivalOnDifferentDaysX": "Êtes-vous sûr d'avoir été assis dans le '{X}' pendant plusieurs jours ?",
@@ -595,6 +596,7 @@
     "weekly": "Hebdomadaire",
     "white": "Blanc",
     "width": "Largeur",
+    "withdrawApproval": "Retirer l’approbation",
     "XDetails": "Détails de {X}"
   },
   "languages": {
@@ -622,6 +624,11 @@
         "lastParagraph": "{commentator} a écrit : '{comment}'",
         "paragraph": "Une nouvelle demande d'avance de {owner} vient juste d'arriver.",
         "subject": "🆕 Nouvelle demande d'avance"
+      },
+      "APPROVAL_WITHDRAWN": {
+        "lastParagraph": "{commentator} a écrit : '{comment}'",
+        "paragraph": "L’approbation de votre avance a été retirée.",
+        "subject": "↩️ Approbation de l’avance retirée"
       },
       "APPROVED": {
         "confirmationLine": "Une fois l'argent reçu, vous pouvez le confirmer [ici]({- confirmLink}).",
@@ -722,6 +729,11 @@
         "lastParagraph": "{commentator} a écrit : '{comment}'",
         "paragraph": "Une nouvelle demande de voyage de {owner} vient juste d'arriver.",
         "subject": "🆕 Nouveau voyage"
+      },
+      "APPROVAL_WITHDRAWN": {
+        "lastParagraph": "{commentator} a écrit : '{comment}'",
+        "paragraph": "L’approbation de votre voyage a été retirée.",
+        "subject": "↩️ Approbation du voyage retirée"
       },
       "APPROVED": {
         "lastParagraph": "{commentator} a écrit : '{comment}'",

--- a/common/locales/kk.json
+++ b/common/locales/kk.json
@@ -25,6 +25,7 @@
     "areYouSureDelete": "Бұл өшіруді аяқтауыңызға сенімдісіз бе? Егер өшірілсе, ол қайта қалпына келтірілмейді!",
     "areYouSureEdit": "Өңдеуді бастауыңызға сенімдісіз бе?",
     "areYouSureMerge": "Бұл пайдаланушыларды біріктіргіңіз келетіні рас па? Бұл қайтымсыз.",
+    "areYouSureWithdrawApproval": "Бұл бекітуді қайтарып алғыңыз келетініне сенімдісіз бе?",
     "conflict": "Қақтығыс!",
     "countryChangeBetweenStages": "Кезеңдер арасындағы елдің ауысуы",
     "departureAndArrivalOnDifferentDaysX": "'{X}' ішінде бірнеше күн бойы отырдыңыз ба, сенімдісіз бе?",
@@ -595,6 +596,7 @@
     "weekly": "Апта сайын",
     "white": "Ақ",
     "width": "Ен",
+    "withdrawApproval": "Бекітуді қайтарып алу",
     "XDetails": "{X}өлшемдері"
   },
   "languages": {
@@ -622,6 +624,11 @@
         "lastParagraph": "{commentator} жазды: '{comment}'",
         "paragraph": "{owner}-ден жаңа аванс сұранысы келді.",
         "subject": "🆕 Жаңа аванс сұранысы"
+      },
+      "APPROVAL_WITHDRAWN": {
+        "lastParagraph": "{commentator} жазды: '{comment}'",
+        "paragraph": "Авансыңыздың бекітуі қайтарып алынды.",
+        "subject": "↩️ Аванс бекітуі қайтарып алынды"
       },
       "APPROVED": {
         "confirmationLine": "Ақша қолыңызға тиген соң, [мұнда]({- confirmLink}) растауға болады.",
@@ -722,6 +729,11 @@
         "lastParagraph": "{commentator} жазды: '{comment}'",
         "paragraph": "{owner} тарапынан жаңа саяхат өтініші жаңа түсті.",
         "subject": "🆕 Жаңа саяхат"
+      },
+      "APPROVAL_WITHDRAWN": {
+        "lastParagraph": "{commentator} жазды: '{comment}'",
+        "paragraph": "Сапарыңыздың бекітуі қайтарып алынды.",
+        "subject": "↩️ Сапар бекітуі қайтарып алынды"
       },
       "APPROVED": {
         "lastParagraph": "{commentator} жазды: '{comment}'",

--- a/common/locales/ru.json
+++ b/common/locales/ru.json
@@ -25,6 +25,7 @@
     "areYouSureDelete": "Вы уверены, что хотите удалить это? Это действие НЕ МОЖЕТ быть отменено!",
     "areYouSureEdit": "Вы уверены, что хотите это изменить?",
     "areYouSureMerge": "Вы уверены, что хотите объединить этих пользователей? Это действие необратимо.",
+    "areYouSureWithdrawApproval": "Вы уверены, что хотите отозвать это утверждение?",
     "conflict": "Конфликт!",
     "countryChangeBetweenStages": "Смена страны между последовательными этапами",
     "departureAndArrivalOnDifferentDaysX": "Вы уверены, что провели несколько дней в '{X}'?",
@@ -595,6 +596,7 @@
     "weekly": "Еженедельно",
     "white": "Белый",
     "width": "Ширина",
+    "withdrawApproval": "Отозвать утверждение",
     "XDetails": "{X}детали"
   },
   "languages": {
@@ -622,6 +624,11 @@
         "lastParagraph": "{commentator} написал: '{comment}'",
         "paragraph": "Новая заявка на аванс от {owner} только что поступила.",
         "subject": "🆕 Новая заявка на аванс"
+      },
+      "APPROVAL_WITHDRAWN": {
+        "lastParagraph": "{commentator} написал(а): '{comment}'",
+        "paragraph": "Утверждение вашего аванса было отозвано.",
+        "subject": "↩️ Утверждение аванса отозвано"
       },
       "APPROVED": {
         "confirmationLine": "Как только получите деньги, можете подтвердить [здесь]({- confirmLink}).",
@@ -722,6 +729,11 @@
         "lastParagraph": "{commentator} написал: '{comment}'",
         "paragraph": "Поступил новый запрос на поездку от {owner}.",
         "subject": "🆕 Новая поездка"
+      },
+      "APPROVAL_WITHDRAWN": {
+        "lastParagraph": "{commentator} написал(а): '{comment}'",
+        "paragraph": "Утверждение вашей поездки было отозвано.",
+        "subject": "↩️ Утверждение поездки отозвано"
       },
       "APPROVED": {
         "lastParagraph": "{commentator} написал: '{comment}'",

--- a/frontend/src/components/advance/ApprovePage.vue
+++ b/frontend/src/components/advance/ApprovePage.vue
@@ -36,6 +36,14 @@
                   </button>
                 </template>
               </Advance>
+              <div v-if="canWithdrawApproval(modalAdvance as AdvanceSimple<string>)" class="mt-3">
+                <label for="withdrawAdvanceApprovalComment" class="form-label">{{ t('labels.comment') }}</label>
+                <CTextArea id="withdrawAdvanceApprovalComment" v-model="withdrawalComment" />
+                <button type="button" class="btn btn-danger mt-3" :disabled="modalFormIsLoading" @click="withdrawApproval()">
+                  <span v-if="modalFormIsLoading" class="spinner-border spinner-border-sm"></span>
+                  {{ t('labels.withdrawApproval') }}
+                </button>
+              </div>
               <form class="mb-2 mt-3" v-if="isOffsetFormVisible" @submit.prevent="offsetAdvance(modalAdvance._id, offsetAmount)">
                 <div class="row gy-3">
                   <label for="amount" class="col-form-label col-auto">
@@ -134,6 +142,7 @@ import AdvanceForm from '@/components/advance/forms/AdvanceForm.vue'
 import ModalComponent from '@/components/elements/ModalComponent.vue'
 import RefStringBadge from '@/components/elements/RefStringBadge.vue'
 import StateBadge from '@/components/elements/StateBadge.vue'
+import CTextArea from '@/components/elements/TextArea.vue'
 
 const props = defineProps<{ _id?: string }>()
 const router = useRouter()
@@ -146,6 +155,7 @@ const modalFormIsLoading = ref(false)
 const isOffsetFormVisible = ref(false)
 const offsetAmount = ref(0)
 const offsetSubject = ref('')
+const withdrawalComment = ref('')
 
 const modalComp = useTemplateRef('modalComp')
 const advanceList = useTemplateRef('advanceList')
@@ -170,6 +180,7 @@ function resetModal() {
   isOffsetFormVisible.value = false
   offsetAmount.value = 0
   offsetSubject.value = ''
+  withdrawalComment.value = ''
   router.push('/approve/advance')
 }
 function resetAndHide() {
@@ -178,6 +189,10 @@ function resetAndHide() {
 }
 
 function canDeleteAdvance(advance: AdvanceSimple<string>) {
+  return advance.state === AdvanceState.APPROVED && !advance.receivedOn && advance.offsetAgainst.length === 0
+}
+
+function canWithdrawApproval(advance: AdvanceSimple<string>) {
   return advance.state === AdvanceState.APPROVED && !advance.receivedOn && advance.offsetAgainst.length === 0
 }
 
@@ -223,6 +238,23 @@ async function deleteAdvance(_id: string) {
   const result = await API.deleter('approve/advance', { _id })
   modalFormIsLoading.value = false
   if (result) {
+    advanceList.value?.loadFromServer()
+    approvedAdvanceList.value?.loadFromServer()
+    resetAndHide()
+  }
+}
+
+async function withdrawApproval() {
+  if (!modalAdvance.value._id || !confirm(t('alerts.areYouSureWithdrawApproval'))) {
+    return
+  }
+  modalFormIsLoading.value = true
+  const result = await API.setter<AdvanceSimple<string>>('approve/advance/withdrawApproval', {
+    _id: modalAdvance.value._id,
+    comment: withdrawalComment.value || undefined
+  })
+  modalFormIsLoading.value = false
+  if (result.ok) {
     advanceList.value?.loadFromServer()
     approvedAdvanceList.value?.loadFromServer()
     resetAndHide()

--- a/frontend/src/components/travel/ApprovePage.vue
+++ b/frontend/src/components/travel/ApprovePage.vue
@@ -67,7 +67,17 @@
           :loading="modalFormIsLoading"
           @cancel="resetAndHide()"
           @decision="(d, c) => approveTravel((modalTravel as TravelSimple)!, d, c)" />
-        <TravelApply v-else-if="modalTravel.state === TravelState.APPROVED" :travel="(modalTravel as TravelSimple)" />
+        <template v-else-if="modalTravel.state === TravelState.APPROVED">
+          <TravelApply :travel="(modalTravel as TravelSimple)" />
+          <div class="mb-3">
+            <label for="withdrawTravelApprovalComment" class="form-label">{{ t('labels.comment') }}</label>
+            <CTextArea id="withdrawTravelApprovalComment" v-model="withdrawalComment" />
+          </div>
+          <button type="button" class="btn btn-danger" :disabled="modalFormIsLoading" @click="withdrawApproval()">
+            <span v-if="modalFormIsLoading" class="spinner-border spinner-border-sm"></span>
+            {{ t('labels.withdrawApproval') }}
+          </button>
+        </template>
         <TravelApplyForm
           v-else-if="modalMode !== 'view'"
           :mode="modalMode"
@@ -125,6 +135,7 @@
         </button>
         <hr class="hr" >
         <TravelList
+          ref="approvedTravelList"
           endpoint="approve/travel"
           :stateFilter="show"
           :columns-to-hide="['state', 'addUp.totalTotal', 'addUp.totalBalance', 'updatedAt', 'report', 'organisation', 'bookingRemark','addUp.totalAdvance', 'reference']"
@@ -145,6 +156,7 @@ import DateInput from '@/components/elements/DateInput.vue'
 import ModalComponent from '@/components/elements/ModalComponent.vue'
 import RefStringBadge from '@/components/elements/RefStringBadge.vue'
 import StateBadge from '@/components/elements/StateBadge.vue'
+import CTextArea from '@/components/elements/TextArea.vue'
 import TravelApply from '@/components/travel/elements/TravelApplication.vue'
 import TravelApplyForm from '@/components/travel/forms/TravelApplyForm.vue'
 import TravelApproveForm from '@/components/travel/forms/TravelApproveForm.vue'
@@ -168,9 +180,11 @@ const approvedTravelsReportForm = ref({
 const modalMode = ref<ModalMode>('view')
 const show = ref<null | TravelState.APPROVED>(null)
 const modalFormIsLoading = ref(false)
+const withdrawalComment = ref('')
 
 const modalComp = useTemplateRef('modalComp')
 const travelList = useTemplateRef('travelList')
+const approvedTravelList = useTemplateRef('approvedTravelList')
 
 const isDownloading = ref('')
 const isDownloadingFn = () => isDownloading
@@ -194,6 +208,7 @@ function hideModal() {
 function resetModal() {
   modalTravel.value = {}
   modalMode.value = 'view'
+  withdrawalComment.value = ''
   router.push('/approve/travel')
 }
 function resetAndHide() {
@@ -211,6 +226,22 @@ async function approveTravel(travel: Partial<TravelSimple>, decision: 'approved'
       travelList.value?.loadFromServer()
       resetAndHide()
     }
+  }
+}
+async function withdrawApproval() {
+  if (!modalTravel.value._id || !confirm(t('alerts.areYouSureWithdrawApproval'))) {
+    return
+  }
+  modalFormIsLoading.value = true
+  const result = await API.setter<TravelSimple>('approve/travel/withdrawApproval', {
+    _id: modalTravel.value._id,
+    comment: withdrawalComment.value || undefined
+  })
+  modalFormIsLoading.value = false
+  if (result.ok) {
+    travelList.value?.loadFromServer()
+    approvedTravelList.value?.loadFromServer()
+    resetAndHide()
   }
 }
 async function showTravel(_id: string) {

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -118,6 +118,12 @@ const routes = [
   },
   { path: '/user', component: () => import('@/components/HomePage.vue'), meta: { requiresAuth: true, offlineCapable: true } },
   {
+    path: '/user/travel/:_id([0-9a-fA-F]{24})',
+    component: () => import('@/components/HomePage.vue'),
+    meta: { requiresAuth: true, offlineCapable: true },
+    props: (route: RouteLocationNormalized) => ({ reportId: route.params._id, reportType: 'travel' })
+  },
+  {
     path: '/advance/:_id([0-9a-fA-F]{24})',
     component: () => import('@/components/HomePage.vue'),
     meta: { requiresAuth: true, offlineCapable: true },


### PR DESCRIPTION
implements #282 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to withdraw approvals for eligible advance and travel requests.
  - Supervisors can provide an optional comment when withdrawing approval.
  - Withdrawn items return to a rejected state and can be submitted for approval again.
  - Added owner notifications and email messages for withdrawn approvals.
  - Added direct links to relevant travel and advance details.

- **Bug Fixes**
  - Prevented approval withdrawal when reports are already booked, received, offset, or otherwise no longer eligible.

- **Localization**
  - Added withdrawal-related text in English, German, Spanish, French, Kazakh, and Russian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->