### PR TITLE
fix: resolve organisation for report emails after queue serialization

### DIFF
--- a/backend/integrations/reports/email.ts
+++ b/backend/integrations/reports/email.ts
@@ -51,8 +51,6 @@ export async function sendReportViaMail(
   const { snapshot } = createOperationServices()
   const { connectionSettings, displaySettings, printerSettings, travelSettings } = snapshot
   if (connectionSettings.PDFReportsViaEmail.sendPDFReportsToOrganisationEmail) {
-    // the report is JSON-serialized through the integration queue, so
-    // project.organisation is a plain id string here — never access ._id on it
     const org = await Organisation.findOne({ _id: idDocumentToId(report.project.organisation) })
     if (org?.reportEmail) {
       const mailClient = await getMailClient()

--- a/backend/integrations/reports/email.ts
+++ b/backend/integrations/reports/email.ts
@@ -2,6 +2,7 @@ import {
   Advance,
   ExpenseReport,
   HealthCareCost,
+  idDocumentToId,
   reportIsAdvance,
   reportIsHealthCareCost,
   reportIsTravel,
@@ -50,7 +51,9 @@ export async function sendReportViaMail(
   const { snapshot } = createOperationServices()
   const { connectionSettings, displaySettings, printerSettings, travelSettings } = snapshot
   if (connectionSettings.PDFReportsViaEmail.sendPDFReportsToOrganisationEmail) {
-    const org = await Organisation.findOne({ _id: report.project.organisation._id })
+    // the report is JSON-serialized through the integration queue, so
+    // project.organisation is a plain id string here — never access ._id on it
+    const org = await Organisation.findOne({ _id: idDocumentToId(report.project.organisation) })
     if (org?.reportEmail) {
       const mailClient = await getMailClient()
       const lng = connectionSettings.PDFReportsViaEmail.locale


### PR DESCRIPTION
### Problem

Since the integrations refactoring, report emails to the organisation (`PDFReportsViaEmail.sendPDFReportsToOrganisationEmail`) are never sent. The failure is completely silent: the `reports.email.send` job is enqueued and finishes as *completed*, no error is logged — the mail just never goes out.

### Root cause

The report is JSON-serialized through the integration queue, so in the worker `report.project.organisation` is a **plain id string**, not a populated document or ObjectId. `sendReportViaMail` accesses `._id` on it:

```ts
const org = await Organisation.findOne({ _id: report.project.organisation._id }) // undefined!
```

`Organisation.findOne({ _id: undefined })` matches nothing, so the function takes the silent `org?.reportEmail` early-exit. (Before the refactoring this worked because the same expression ran in-process on a mongoose ObjectId, where `._id` returns the id itself.)

### Fix

Use `idDocumentToId`, which handles both populated documents and plain ids.

Verified against a production instance where organisation report mails had silently stopped after updating to v2.6.3 — with this change they are sent again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128iHKnuevVg5UoDSshv3NC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved report email processing by correctly identifying the associated organization from serialized integration data.
  * Prevented errors when organization references are provided in normalized identifier format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->