### PR TITLE
fix: A1 notification never triggered for newly created travels

### DIFF
--- a/backend/integrations/notifications/a1.ts
+++ b/backend/integrations/notifications/a1.ts
@@ -4,6 +4,7 @@ import escapeHtml from 'escape-html'
 import { createOperationServices } from '../../factory.js'
 import i18n from '../../i18n.js'
 import Organisation from '../../models/organisation.js'
+import Travel from '../../models/travel.js'
 import { type IntegrationEvent, type IntegrationEventHandlerMap } from '../events.js'
 import { Integration } from '../integration.js'
 import { enqueueMail } from './email.js'
@@ -12,8 +13,11 @@ type ApprovedTravelEvent = Extract<IntegrationEvent, { type: 'travel.directly_ap
 
 class A1NotificationIntegration extends Integration {
   private readonly notifyAboutApprovedTravel = async ({ report }: ApprovedTravelEvent) => {
-    if (report.isCrossBorder && report.destinationPlace.country.needsA1Certificate) {
-      await sendA1Notification(report)
+    // on newly created travels the event payload is unpopulated (country is a
+    // plain country code), so reload the travel to get country and owner populated
+    const travel = await Travel.findOne({ _id: report._id }).lean()
+    if (travel?.isCrossBorder && travel.destinationPlace.country.needsA1Certificate) {
+      await sendA1Notification(travel as TravelSimple)
     }
   }
 


### PR DESCRIPTION
### Problem

The A1 certificate notification is never sent for newly created (directly approved) travels, even when "cross-border travel" is checked and the destination country has `needsA1Certificate: true`. Silent failure — no error anywhere.

### Root cause

For newly created documents the `travel.directly_approved` event payload is **unpopulated** (`new Model(...).save()` does not run the populate hooks): `destinationPlace.country` is the plain country code string, so

```ts
if (report.isCrossBorder && report.destinationPlace.country.needsA1Certificate) // undefined on a string
```

is always false and the handler skips the notification.

Historically this path was broken too, but it was masked: before the integrations refactoring the A1 mail was (re-)sent on every travel edit, and the edit path loads the document populated. With the edit-resend gone, no A1 mail is ever sent.

### Fix

Reload the travel from the database in the event handler (populate hooks apply) before evaluating the condition. This also fixes the owner name and country data rendered into the notification mail, which were equally unpopulated on the create path.

Verified against a production instance: with this change, creating a cross-border travel to an A1 country triggers the notification again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128iHKnuevVg5UoDSshv3NC