### PR TITLE
feat: prefill departure of the first stage with the travel's start date

### DIFF
--- a/frontend/src/components/travel/TravelPage.vue
+++ b/frontend/src/components/travel/TravelPage.vue
@@ -159,7 +159,10 @@
         <div class="col-lg-auto col-12">
           <div class="row g-1 mb-4">
             <div class="col-auto">
-              <button class="btn btn-secondary" @click="isReadOnly ? null : showModal('add', 'stage', undefined)" :disabled="isReadOnly">
+              <button
+                class="btn btn-secondary"
+                @click="isReadOnly ? null : showModal('add', 'stage', travel.stages.length === 0 ? { departure: travel.startDate } : undefined)"
+                :disabled="isReadOnly">
                 <i class="bi bi-plus-lg"></i>
                 <span class="ms-1 d-none d-md-inline">{{ t('labels.addX', { X: t('labels.stage') }) }}</span>
                 <span class="ms-1 d-md-none">{{ t('labels.stage') }}</span>


### PR DESCRIPTION
When adding the first stage of a travel the departure date now defaults to the travel's start date instead of starting empty — one less field to fill in the most common case. Editing existing stages and adding further stages are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128iHKnuevVg5UoDSshv3NC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * When adding the first stage to a travel, the departure date now defaults to the travel’s start date.
  * Subsequent stages continue without an automatic default date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->