### PR TITLE
Feature: show action counts

### DIFF
--- a/backend/actionCounts.ts
+++ b/backend/actionCounts.ts
@@ -1,0 +1,72 @@
+import {
+  type ActionAccess,
+  type ActionCounts,
+  AdvanceState,
+  actionAccesses,
+  ExpenseReportState,
+  HealthCareCostState,
+  TravelState,
+  type User
+} from 'abrechnung-common/types.js'
+import { Model, PipelineStage, Types } from 'mongoose'
+import Advance from './models/advance.js'
+import ExpenseReport from './models/expenseReport.js'
+import HealthCareCost from './models/healthCareCost.js'
+import Travel from './models/travel.js'
+
+interface CountDefinition {
+  access: ActionAccess
+  state: number
+}
+
+interface StateCount {
+  _id: number
+  count: number
+}
+
+const countDefinitions = {
+  advance: [
+    { access: 'approve/advance', state: AdvanceState.APPLIED_FOR },
+    { access: 'book/advance', state: AdvanceState.APPROVED }
+  ],
+  travel: [
+    { access: 'approve/travel', state: TravelState.APPLIED_FOR },
+    { access: 'examine/travel', state: TravelState.IN_REVIEW },
+    { access: 'book/travel', state: TravelState.REVIEW_COMPLETED }
+  ],
+  expenseReport: [
+    { access: 'examine/expenseReport', state: ExpenseReportState.IN_REVIEW },
+    { access: 'book/expenseReport', state: ExpenseReportState.REVIEW_COMPLETED }
+  ],
+  healthCareCost: [
+    { access: 'examine/healthCareCost', state: HealthCareCostState.IN_REVIEW },
+    { access: 'book/healthCareCost', state: HealthCareCostState.REVIEW_COMPLETED }
+  ]
+} as const satisfies Record<string, readonly CountDefinition[]>
+
+async function countStates<ModelType>(model: Model<ModelType>, definitions: readonly CountDefinition[], user: User<Types.ObjectId>) {
+  const allowedDefinitions = definitions.filter(({ access }) => user.access[access])
+  if (allowedDefinitions.length === 0) return []
+
+  const match: PipelineStage.Match['$match'] = { historic: false, state: { $in: allowedDefinitions.map(({ state }) => state) } }
+  if (user.projects.supervised.length > 0) {
+    match.project = { $in: user.projects.supervised }
+  }
+
+  const counts = await model.aggregate<StateCount>([{ $match: match }, { $group: { _id: '$state', count: { $sum: 1 } } }])
+  const countsByState = new Map(counts.map(({ _id, count }) => [_id, count]))
+  return allowedDefinitions.map(({ access, state }) => [access, countsByState.get(state) ?? 0] as const)
+}
+
+export async function getActionCounts(user: User<Types.ObjectId>) {
+  const counts = Object.fromEntries(actionAccesses.map((access) => [access, 0])) as ActionCounts
+  const results = await Promise.all([
+    countStates(Advance, countDefinitions.advance, user),
+    countStates(Travel, countDefinitions.travel, user),
+    countStates(ExpenseReport, countDefinitions.expenseReport, user),
+    countStates(HealthCareCost, countDefinitions.healthCareCost, user)
+  ])
+
+  for (const [access, count] of results.flat()) counts[access] = count
+  return counts
+}

--- a/backend/controller/userController.ts
+++ b/backend/controller/userController.ts
@@ -12,6 +12,7 @@ import {
 import { DeleteResult } from 'mongodb'
 import { mongo, Types } from 'mongoose'
 import { PushSubscription } from 'web-push'
+import { getActionCounts } from '../actionCounts.js'
 import { generateBearerToken, hashToken } from '../authStrategies/http-bearer.js'
 import ENV from '../env.js'
 import { documentFileHandler, fileHandler } from '../helper.js'
@@ -38,6 +39,11 @@ export class UserController extends Controller {
   @Get()
   public getMe(@Request() request: AuthenticatedExpressRequest) {
     return { data: request.user as IUser }
+  }
+
+  @Get('actionCounts')
+  public async getActionCounts(@Request() request: AuthenticatedExpressRequest) {
+    return { data: await getActionCounts(request.user) }
   }
 
   @Get('token')

--- a/backend/models/advance.ts
+++ b/backend/models/advance.ts
@@ -252,6 +252,7 @@ schema.post('save', async function () {
   }
 })
 
+schema.index({ historic: 1, state: 1, project: 1 })
 schema.index({ name: 'text', reason: 'text', 'comments.text': 'text' }, { weights: { name: 10, reason: 6, 'comments.text': 3 } })
 
 export default model('Advance', schema)

--- a/backend/models/expenseReport.ts
+++ b/backend/models/expenseReport.ts
@@ -214,6 +214,7 @@ schema.post('save', async function () {
   }
 })
 
+schema.index({ historic: 1, state: 1, project: 1 })
 schema.index(
   { name: 'text', reason: 'text', 'comments.text': 'text', 'expenses.description': 'text' },
   { weights: { name: 10, 'expenses.description': 6, 'comments.text': 3 } }

--- a/backend/models/healthCareCost.ts
+++ b/backend/models/healthCareCost.ts
@@ -144,6 +144,7 @@ schema.post('save', async function () {
   }
 })
 
+schema.index({ historic: 1, state: 1, project: 1 })
 schema.index(
   { name: 'text', 'comments.text': 'text', 'expenses.description': 'text' },
   { weights: { name: 10, 'expenses.description': 6, 'comments.text': 3 } }

--- a/backend/models/travel.ts
+++ b/backend/models/travel.ts
@@ -284,6 +284,7 @@ schema.post('save', async function () {
   }
 })
 
+schema.index({ historic: 1, state: 1, project: 1 })
 schema.index(
   { name: 'text', 'comments.text': 'text', reason: 'text', 'destinationPlace.place': 'text', 'expenses.description': 'text' },
   { weights: { name: 10, reason: 6, 'destinationPlace.place': 4, 'expenses.description': 4, 'comments.text': 3 } }

--- a/backend/tests/api/actionCounts.ts
+++ b/backend/tests/api/actionCounts.ts
@@ -1,0 +1,95 @@
+import { type ActionCounts, State } from 'abrechnung-common/types.js'
+import { Base64 } from 'abrechnung-common/utils/encoding.js'
+import test from 'ava'
+import { Types } from 'mongoose'
+import { shutdown } from '../../app.js'
+import Project from '../../models/project.js'
+import Travel from '../../models/travel.js'
+import User from '../../models/user.js'
+import createAgent, { loginUser } from '../_agent.js'
+
+const agent = await createAgent()
+const reportName = `Action count test ${Date.now()}`
+
+let projectId = ''
+let userId = ''
+let originalProjects = { assigned: [] as string[], supervised: [] as string[] }
+
+function toIds(entries: Array<{ _id?: string } | string>) {
+  return entries.map((entry) => (typeof entry === 'string' ? entry : entry._id)).filter((entry): entry is string => Boolean(entry))
+}
+
+test.serial.before(async () => {
+  await loginUser(agent, 'admin')
+  const projectsResponse = await agent.get('/admin/project')
+  const project = projectsResponse.body.data[0]
+  const newProjectResponse = await agent
+    .post('/admin/project')
+    .send({ identifier: `COUNT-${Date.now()}`, name: reportName, organisation: project.organisation, balance: { amount: 0 } })
+  projectId = newProjectResponse.body.result._id
+
+  const userResponse = await agent.get('/admin/user').query({ filterJSON: Base64.encode(JSON.stringify({ 'fk.ldapauth': 'zoidberg' })) })
+  const user = userResponse.body.data[0]
+  userId = user._id
+  originalProjects = { assigned: toIds(user.projects.assigned), supervised: toIds(user.projects.supervised) }
+  await agent
+    .post('/admin/user')
+    .send({ _id: userId, access: user.access, projects: { assigned: originalProjects.assigned, supervised: [projectId] } })
+
+  const states = [
+    State.APPLIED_FOR,
+    State.APPLIED_FOR,
+    State.IN_REVIEW,
+    State.IN_REVIEW,
+    State.IN_REVIEW,
+    State.BOOKABLE,
+    State.BOOKABLE,
+    State.BOOKABLE,
+    State.BOOKABLE,
+    State.BOOKED
+  ]
+  await Travel.collection.insertMany([
+    ...states.map((state) => ({
+      _id: new Types.ObjectId(),
+      name: reportName,
+      historic: false,
+      project: new Types.ObjectId(projectId),
+      state
+    })),
+    { _id: new Types.ObjectId(), name: reportName, historic: true, project: new Types.ObjectId(projectId), state: State.APPLIED_FOR },
+    { _id: new Types.ObjectId(), name: reportName, historic: false, project: new Types.ObjectId(), state: State.APPLIED_FOR }
+  ])
+})
+
+test.serial('GET /user/actionCounts returns only actionable, permitted and project-scoped reports', async (t) => {
+  await loginUser(agent, 'travel')
+  const response = await agent.get('/user/actionCounts')
+
+  t.is(response.status, 200)
+  t.deepEqual(response.body.data as ActionCounts, {
+    'approve/advance': 0,
+    'approve/travel': 2,
+    'examine/travel': 3,
+    'examine/expenseReport': 0,
+    'examine/healthCareCost': 0,
+    'book/advance': 0,
+    'book/travel': 4,
+    'book/expenseReport': 0,
+    'book/healthCareCost': 0
+  })
+})
+
+test.serial('GET /user/actionCounts does not expose counts without action access', async (t) => {
+  await loginUser(agent, 'user')
+  const response = await agent.get('/user/actionCounts')
+
+  t.is(response.status, 200)
+  t.true(Object.values(response.body.data as ActionCounts).every((count) => count === 0))
+})
+
+test.serial.after.always('Clean up action count fixtures', async () => {
+  await Travel.collection.deleteMany({ name: reportName })
+  if (userId && originalProjects) await User.updateOne({ _id: userId }, { projects: originalProjects })
+  if (projectId) await Project.deleteOne({ _id: projectId })
+  await shutdown()
+})

--- a/common/types.ts
+++ b/common/types.ts
@@ -906,6 +906,20 @@ export const accesses = [
 ] as const
 export type Access = (typeof accesses)[number]
 
+export const actionAccesses = [
+  'approve/advance',
+  'approve/travel',
+  'examine/travel',
+  'examine/expenseReport',
+  'examine/healthCareCost',
+  'book/advance',
+  'book/travel',
+  'book/expenseReport',
+  'book/healthCareCost'
+] as const satisfies readonly Access[]
+export type ActionAccess = (typeof actionAccesses)[number]
+export type ActionCounts = Record<ActionAccess, number>
+
 export const meals = ['breakfast', 'lunch', 'dinner'] as const
 export type Meal = (typeof meals)[number]
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -45,6 +45,7 @@
             <router-link :to="'/' + access" class="nav-link link-body-emphasis d-flex align-items-center">
               <i v-for="icon of APP_DATA.displaySettings.accessIcons[access]" :class="'bi bi-' + icon"></i>
               <span class="ms-1">{{ t('accesses.' + access) }}</span>
+              <ActionCountBadge :count="getActionCount(access)" />
             </router-link>
           </li>
         </template>
@@ -52,10 +53,14 @@
       <template v-else>
         <li class="nav-item dropdown me-2">
           <a
-            class="nav-link link-body-emphasis d-flex align-items-center dropdown-toggle clickable"
+            class="nav-link link-body-emphasis d-flex align-items-center dropdown-toggle clickable position-relative"
             role="button"
             data-bs-toggle="dropdown">
-            <i class="fs-4 bi bi-menu-down"></i><span class="ms-1">{{ t('labels.menu') }}</span>
+            <i class="fs-4 bi bi-menu-down"></i>
+            <span class="ms-1">{{ t('labels.menu') }}</span>
+            <ActionCountBadge
+              :count="actionCountState.total.value"
+              class="menu-action-count position-absolute top-0 end-0" />
           </a>
           <ul class="dropdown-menu dropdown-menu-end">
             <template v-for="(accesses,i) of orderdAccessList">
@@ -63,6 +68,7 @@
                 <router-link :to="'/' + access" class="d-flex align-items-center dropdown-item">
                   <i v-for="icon of APP_DATA.displaySettings.accessIcons[access]" :class="'fs-5 bi bi-' + icon"></i>
                   <span class="ms-1">{{ t('accesses.' + access) }}</span>
+                  <ActionCountBadge :count="getActionCount(access)" class="ms-auto" />
                 </router-link>
               </li>
               <li v-if="i !== orderdAccessList.length - 1">
@@ -139,7 +145,9 @@
 
 <script lang="ts" setup>
 import {
+  ActionAccess,
   Access,
+  actionAccesses,
   AnyState,
   accesses,
   getReportTypeFromModelName,
@@ -153,10 +161,12 @@ import {
   User
 } from 'abrechnung-common/types.js'
 import { getById } from 'abrechnung-common/utils/scripts.js'
-import { computed, onMounted, ref, useTemplateRef } from 'vue'
+import { computed, onMounted, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
+import { actionCountState, refreshActionCounts, startActionCountUpdates } from '@/actionCounts.js'
 import API from '@/api.js'
+import ActionCountBadge from '@/components/elements/ActionCountBadge.vue'
 import AlertComponent from '@/components/elements/AlertComponent.vue'
 import FooterComponent from '@/components/elements/FooterComponent.vue'
 import HeaderComponent from '@/components/elements/HeaderComponent.vue'
@@ -177,6 +187,7 @@ const APP_DATA = APP_LOADER.data
 const APP_LOGIN_DATA = APP_LOADER.loginData
 const loadState = APP_LOADER.state
 const alreadyInstalled = window.matchMedia('(display-mode: standalone)').matches
+const actionCounts = actionCountState.counts
 
 const installationBannerRef = useTemplateRef('installBanner')
 const offlineBannerRef = useTemplateRef('offlineBanner')
@@ -216,6 +227,11 @@ const orderdAccessList = computed(() => {
   return Object.values(groups)
 })
 const flatAccessList = computed(() => orderdAccessList.value.flat())
+
+function getActionCount(access: Access) {
+  if (!actionCounts.value || !actionAccesses.includes(access as ActionAccess)) return 0
+  return actionCounts.value[access as ActionAccess]
+}
 
 function showInstallBanner() {
   if (installationBannerRef.value) {
@@ -274,10 +290,25 @@ function getNameFromUserId(userId: string) {
 }
 
 onMounted(() => {
+  startActionCountUpdates()
   if (!offlineBannerRef.value?.isOffline) {
     subscribeToPush()
   }
 })
+
+watch(
+  APP_DATA,
+  (data) => {
+    if (data) void refreshActionCounts()
+  },
+  { immediate: true }
+)
 </script>
 
-<style></style>
+<style>
+.menu-action-count {
+  margin-left: 0 !important;
+  padding: 0.2em 0.45em;
+  font-size: 0.625rem;
+}
+</style>

--- a/frontend/src/actionCounts.ts
+++ b/frontend/src/actionCounts.ts
@@ -12,6 +12,7 @@ interface ApiMutationSucceededDetail {
 const counts = ref<ActionCounts | null>(null)
 const total = computed(() => actionAccesses.reduce((sum, access) => sum + (counts.value?.[access] ?? 0), 0))
 let inFlight: Promise<void> | undefined
+let inFlightGeneration: number | undefined
 let refreshQueued = false
 let started = false
 let generation = 0
@@ -35,17 +36,19 @@ function changesActionCounts({ endpoint, method }: ApiMutationSucceededDetail) {
 export function refreshActionCounts(queueAfterInFlight = false) {
   if (!sessionState.isOnline.value || !sessionState.authContext.value) return Promise.resolve()
   if (inFlight) {
-    refreshQueued ||= queueAfterInFlight
+    refreshQueued ||= queueAfterInFlight || inFlightGeneration !== generation
     return inFlight
   }
 
   const requestGeneration = generation
+  inFlightGeneration = requestGeneration
   inFlight = API.getter<ActionCounts>('user/actionCounts', {}, {}, { showAlert: false })
     .then((result) => {
       if (result.ok && requestGeneration === generation) counts.value = result.ok.data
     })
     .finally(() => {
       inFlight = undefined
+      inFlightGeneration = undefined
       if (refreshQueued) {
         refreshQueued = false
         void refreshActionCounts()

--- a/frontend/src/actionCounts.ts
+++ b/frontend/src/actionCounts.ts
@@ -1,0 +1,78 @@
+import { type ActionCounts, actionAccesses } from 'abrechnung-common/types.js'
+import { computed, readonly, ref } from 'vue'
+import API from '@/api.js'
+import { eventBus } from '@/eventBus.js'
+import { registerSessionPurgeHandler, sessionState } from '@/session.js'
+
+interface ApiMutationSucceededDetail {
+  endpoint: string
+  method: 'DELETE' | 'POST'
+}
+
+const counts = ref<ActionCounts | null>(null)
+const total = computed(() => actionAccesses.reduce((sum, access) => sum + (counts.value?.[access] ?? 0), 0))
+let inFlight: Promise<void> | undefined
+let refreshQueued = false
+let started = false
+let generation = 0
+
+const stateChangingPostEndpoints = [
+  /^advance\/(appliedFor|received)$/,
+  /^travel\/(appliedFor|approved|underExamination)$/,
+  /^(expenseReport|healthCareCost)\/(inWork|underExamination)$/,
+  /^approve\/(advance|travel)\/(approved|rejected|withdrawApproval)$/,
+  /^examine\/(travel|expenseReport|healthCareCost)\/(approved|inWork|reviewCompleted|underExamination)$/,
+  /^book\/(advance|travel|expenseReport|healthCareCost)\/booked$/
+]
+const stateChangingDeleteEndpoint =
+  /^(advance|travel|expenseReport|healthCareCost|approve\/advance|examine\/(travel|expenseReport|healthCareCost))$/
+
+function changesActionCounts({ endpoint, method }: ApiMutationSucceededDetail) {
+  if (method === 'DELETE') return stateChangingDeleteEndpoint.test(endpoint)
+  return stateChangingPostEndpoints.some((pattern) => pattern.test(endpoint))
+}
+
+export function refreshActionCounts(queueAfterInFlight = false) {
+  if (!sessionState.isOnline.value || !sessionState.authContext.value) return Promise.resolve()
+  if (inFlight) {
+    refreshQueued ||= queueAfterInFlight
+    return inFlight
+  }
+
+  const requestGeneration = generation
+  inFlight = API.getter<ActionCounts>('user/actionCounts', {}, {}, { showAlert: false })
+    .then((result) => {
+      if (result.ok && requestGeneration === generation) counts.value = result.ok.data
+    })
+    .finally(() => {
+      inFlight = undefined
+      if (refreshQueued) {
+        refreshQueued = false
+        void refreshActionCounts()
+      }
+    })
+  return inFlight
+}
+
+export function startActionCountUpdates() {
+  if (started) return
+  started = true
+
+  window.addEventListener('focus', () => void refreshActionCounts())
+  window.addEventListener('online', () => void refreshActionCounts())
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') void refreshActionCounts()
+  })
+  eventBus.addEventListener('api-mutation-succeeded', (event) => {
+    const detail = (event as CustomEvent<ApiMutationSucceededDetail>).detail
+    if (changesActionCounts(detail)) void refreshActionCounts(true)
+  })
+}
+
+registerSessionPurgeHandler(() => {
+  generation += 1
+  refreshQueued = false
+  counts.value = null
+})
+
+export const actionCountState = { counts: readonly(counts), total: readonly(total) }

--- a/frontend/src/actionCounts.ts
+++ b/frontend/src/actionCounts.ts
@@ -21,6 +21,7 @@ const stateChangingPostEndpoints = [
   /^advance\/(appliedFor|received)$/,
   /^travel\/(appliedFor|approved|underExamination)$/,
   /^(expenseReport|healthCareCost)\/(inWork|underExamination)$/,
+  /^approve\/advance\/bulk$/,
   /^approve\/(advance|travel)\/(approved|rejected|withdrawApproval)$/,
   /^examine\/(travel|expenseReport|healthCareCost)\/(approved|inWork|reviewCompleted|underExamination)$/,
   /^book\/(advance|travel|expenseReport|healthCareCost)\/booked$/

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -2,6 +2,7 @@ import { GETResponse, SETResponse } from 'abrechnung-common/types.js'
 import axios, { AxiosRequestConfig } from 'axios'
 import { Reactive, reactive } from 'vue'
 import ENV from './env.js'
+import { eventBus } from './eventBus.js'
 import i18n from './i18n.js'
 import { logger } from './logger.js'
 import { purgeSession, sessionState } from './session.js'
@@ -63,6 +64,7 @@ class API {
     try {
       const res = await axios.post(`${ENV.VITE_BACKEND_URL}/${endpoint}`, data, Object.assign({ withCredentials: true }, config))
       if (showAlert) this.addAlert({ title: i18n.global.t(res.data.message), type: 'success' })
+      eventBus.dispatchEvent(new CustomEvent('api-mutation-succeeded', { detail: { endpoint, method: 'POST' } }))
       return { ok: (res.data as SETResponse<T>).result }
     } catch (error: unknown) {
       return this.#handleError(error, showAlert)
@@ -83,6 +85,7 @@ class API {
     try {
       const res = await axios.delete(`${ENV.VITE_BACKEND_URL}/${endpoint}`, { params: params, withCredentials: true })
       if (showAlert.success) this.addAlert({ message: '', title: i18n.global.t('alerts.successDeleting'), type: 'success' })
+      eventBus.dispatchEvent(new CustomEvent('api-mutation-succeeded', { detail: { endpoint, method: 'DELETE' } }))
       if (res.data.result) {
         return res.data.result
       }

--- a/frontend/src/components/elements/ActionCountBadge.vue
+++ b/frontend/src/components/elements/ActionCountBadge.vue
@@ -1,0 +1,7 @@
+<template>
+  <span v-if="count > 0" class="badge rounded-pill text-bg-danger ms-2">{{ count }}</span>
+</template>
+
+<script setup lang="ts">
+defineProps<{ count: number }>()
+</script>

--- a/frontend/tests/actionCounts.test.ts
+++ b/frontend/tests/actionCounts.test.ts
@@ -93,6 +93,31 @@ describe('action counts', () => {
     await vi.waitFor(() => expect(API.getter).toHaveBeenCalledTimes(2))
   })
 
+  it('queues a fresh request when the session changes during an in-flight refresh', async () => {
+    let resolveRequest:
+      | ((value: { ok: { data: ActionCounts; meta: { count: number; page: number; limit: number; countPages: number } } }) => void)
+      | undefined
+    const freshCounts = { ...actionCounts, 'approve/advance': 10 }
+    vi.mocked(API.getter)
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveRequest = resolve
+        })
+      )
+      .mockResolvedValueOnce({ ok: { data: freshCounts, meta: { count: 1, page: 1, limit: 1, countPages: 1 } } })
+
+    const staleRequest = refreshActionCounts()
+    testState.purgeHandler?.()
+    const sessionRequest = refreshActionCounts()
+
+    expect(API.getter).toHaveBeenCalledOnce()
+    resolveRequest?.({ ok: { data: actionCounts, meta: { count: 1, page: 1, limit: 1, countPages: 1 } } })
+    await Promise.all([staleRequest, sessionRequest])
+
+    await vi.waitFor(() => expect(API.getter).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => expect(actionCountState.counts.value).toEqual(freshCounts))
+  })
+
   it('does not request counts while offline', async () => {
     testState.isOnline.value = false
     await refreshActionCounts()

--- a/frontend/tests/actionCounts.test.ts
+++ b/frontend/tests/actionCounts.test.ts
@@ -1,0 +1,125 @@
+import type { ActionCounts } from 'abrechnung-common/types.js'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const testState = vi.hoisted(() => ({
+  isOnline: { value: true },
+  authContext: { value: { userId: 'user' } as object | null },
+  purgeHandler: undefined as (() => void) | undefined
+}))
+
+vi.mock('@/api.js', () => ({ default: { getter: vi.fn() } }))
+vi.mock('@/session.js', () => ({
+  registerSessionPurgeHandler: (handler: () => void) => {
+    testState.purgeHandler = handler
+  },
+  sessionState: { authContext: testState.authContext, isOnline: testState.isOnline }
+}))
+
+import { actionCountState, refreshActionCounts, startActionCountUpdates } from '@/actionCounts.js'
+import API from '@/api.js'
+import { eventBus } from '@/eventBus.js'
+
+const actionCounts: ActionCounts = {
+  'approve/advance': 1,
+  'approve/travel': 2,
+  'examine/travel': 3,
+  'examine/expenseReport': 4,
+  'examine/healthCareCost': 5,
+  'book/advance': 6,
+  'book/travel': 7,
+  'book/expenseReport': 8,
+  'book/healthCareCost': 9
+}
+
+beforeAll(() => {
+  const documentTarget = new EventTarget()
+  Object.defineProperty(documentTarget, 'visibilityState', { configurable: true, value: 'visible' })
+  vi.stubGlobal('document', documentTarget)
+  startActionCountUpdates()
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  testState.isOnline.value = true
+  testState.authContext.value = { userId: 'user' }
+  testState.purgeHandler?.()
+  vi.mocked(API.getter).mockResolvedValue({ ok: { data: actionCounts, meta: { count: 1, page: 1, limit: 1, countPages: 1 } } })
+})
+
+describe('action counts', () => {
+  it('loads counts and calculates their sum', async () => {
+    await refreshActionCounts()
+
+    expect(actionCountState.counts.value).toEqual(actionCounts)
+    expect(actionCountState.total.value).toBe(45)
+  })
+
+  it('coalesces concurrent refreshes', async () => {
+    let resolveRequest:
+      | ((value: { ok: { data: ActionCounts; meta: { count: number; page: number; limit: number; countPages: number } } }) => void)
+      | undefined
+    vi.mocked(API.getter).mockReturnValue(
+      new Promise((resolve) => {
+        resolveRequest = resolve
+      })
+    )
+
+    const first = refreshActionCounts()
+    const second = refreshActionCounts()
+    expect(API.getter).toHaveBeenCalledOnce()
+    resolveRequest?.({ ok: { data: actionCounts, meta: { count: 1, page: 1, limit: 1, countPages: 1 } } })
+    await Promise.all([first, second])
+  })
+
+  it('queues a fresh request when a status changes during an in-flight refresh', async () => {
+    let resolveRequest:
+      | ((value: { ok: { data: ActionCounts; meta: { count: number; page: number; limit: number; countPages: number } } }) => void)
+      | undefined
+    vi.mocked(API.getter)
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveRequest = resolve
+        })
+      )
+      .mockResolvedValueOnce({ ok: { data: actionCounts, meta: { count: 1, page: 1, limit: 1, countPages: 1 } } })
+
+    const first = refreshActionCounts()
+    eventBus.dispatchEvent(
+      new CustomEvent('api-mutation-succeeded', { detail: { endpoint: 'examine/travel/reviewCompleted', method: 'POST' } })
+    )
+    resolveRequest?.({ ok: { data: actionCounts, meta: { count: 1, page: 1, limit: 1, countPages: 1 } } })
+    await first
+
+    await vi.waitFor(() => expect(API.getter).toHaveBeenCalledTimes(2))
+  })
+
+  it('does not request counts while offline', async () => {
+    testState.isOnline.value = false
+    await refreshActionCounts()
+
+    expect(API.getter).not.toHaveBeenCalled()
+    expect(actionCountState.counts.value).toBeNull()
+  })
+
+  it('refreshes on focus and relevant successful mutations only', async () => {
+    window.dispatchEvent(new Event('focus'))
+    await vi.waitFor(() => expect(API.getter).toHaveBeenCalledTimes(1))
+
+    eventBus.dispatchEvent(new CustomEvent('api-mutation-succeeded', { detail: { endpoint: 'user/settings', method: 'POST' } }))
+    await Promise.resolve()
+    expect(API.getter).toHaveBeenCalledTimes(1)
+
+    eventBus.dispatchEvent(
+      new CustomEvent('api-mutation-succeeded', { detail: { endpoint: 'examine/travel/reviewCompleted', method: 'POST' } })
+    )
+    await vi.waitFor(() => expect(API.getter).toHaveBeenCalledTimes(2))
+  })
+
+  it('clears counts with the session', async () => {
+    await refreshActionCounts()
+    testState.purgeHandler?.()
+
+    expect(actionCountState.counts.value).toBeNull()
+    expect(actionCountState.total.value).toBe(0)
+  })
+})

--- a/frontend/tests/actionCounts.test.ts
+++ b/frontend/tests/actionCounts.test.ts
@@ -138,6 +138,9 @@ describe('action counts', () => {
       new CustomEvent('api-mutation-succeeded', { detail: { endpoint: 'examine/travel/reviewCompleted', method: 'POST' } })
     )
     await vi.waitFor(() => expect(API.getter).toHaveBeenCalledTimes(2))
+
+    eventBus.dispatchEvent(new CustomEvent('api-mutation-succeeded', { detail: { endpoint: 'approve/advance/bulk', method: 'POST' } }))
+    await vi.waitFor(() => expect(API.getter).toHaveBeenCalledTimes(3))
   })
 
   it('clears counts with the session', async () => {


### PR DESCRIPTION
Fügt projektbezogene Zähler für offene Genehmigungs-, Prüfungs- und Buchungsaufgaben hinzu und zeigt sie als Badges in der Navigation an. Die Zähler werden nach relevanten Statusänderungen aktualisiert; passende Datenbankindizes sowie Backend- und Frontendtests sind enthalten.