### PR TITLE
Feature: admin can view all reports

### DIFF
--- a/backend/controller/adminReportController.ts
+++ b/backend/controller/adminReportController.ts
@@ -1,0 +1,100 @@
+import { Readable } from 'node:stream'
+import { Get, Produces, Query, Request, Route, Security, Tags } from '@tsoa/runtime'
+import { Advance, ExpenseReport, HealthCareCost, Locale, ReportModelName, State, Travel } from 'abrechnung-common/types.js'
+import mongoose, { mongo, Types } from 'mongoose'
+import { createOperationServices } from '../factory.js'
+import { Controller } from './controller.js'
+import { NotFoundError } from './error.js'
+import { AuthenticatedExpressRequest } from './types.js'
+
+type AdminReport =
+  | Travel<Types.ObjectId, mongo.Binary>
+  | ExpenseReport<Types.ObjectId, mongo.Binary>
+  | HealthCareCost<Types.ObjectId, mongo.Binary>
+  | Advance<Types.ObjectId>
+
+async function getCurrentReport(type: ReportModelName, _id: string, printableOnly = false) {
+  const filter = { _id, historic: false, ...(printableOnly ? { state: { $gte: State.BOOKABLE } } : {}) }
+  const report = await mongoose.model<AdminReport>(type).findOne(filter, { history: 0, historic: 0 }).lean()
+  if (!report) {
+    throw new NotFoundError(`No current ${type} with id: '${_id}' found`)
+  }
+  return report
+}
+
+async function getCurrentReportPdf(controller: Controller, type: ReportModelName, _id: string, language: Locale) {
+  const report = await getCurrentReport(type, _id, true)
+  const pdf = await createOperationServices().reportPrinter.print(report, language)
+  controller.setHeader('Content-disposition', `attachment; filename*=UTF-8''${encodeURIComponent(report.name)}.pdf`)
+  controller.setHeader('Content-Type', 'application/pdf')
+  controller.setHeader('Content-Length', pdf.length)
+  return Readable.from([pdf])
+}
+
+@Tags('Admin', 'Travel')
+@Route('admin/travel')
+@Security('cookieAuth', ['admin'])
+@Security('httpBearer', ['admin'])
+export class AdminTravelController extends Controller {
+  @Get()
+  public async get(@Query() _id: string) {
+    return { data: await getCurrentReport('Travel', _id) }
+  }
+
+  @Get('report')
+  @Produces('application/pdf')
+  public async getReport(@Query() _id: string, @Request() request: AuthenticatedExpressRequest) {
+    return await getCurrentReportPdf(this, 'Travel', _id, request.user.settings.language)
+  }
+}
+
+@Tags('Admin', 'Expense Report')
+@Route('admin/expenseReport')
+@Security('cookieAuth', ['admin'])
+@Security('httpBearer', ['admin'])
+export class AdminExpenseReportController extends Controller {
+  @Get()
+  public async get(@Query() _id: string) {
+    return { data: await getCurrentReport('ExpenseReport', _id) }
+  }
+
+  @Get('report')
+  @Produces('application/pdf')
+  public async getReport(@Query() _id: string, @Request() request: AuthenticatedExpressRequest) {
+    return await getCurrentReportPdf(this, 'ExpenseReport', _id, request.user.settings.language)
+  }
+}
+
+@Tags('Admin', 'Health Care Cost')
+@Route('admin/healthCareCost')
+@Security('cookieAuth', ['admin'])
+@Security('httpBearer', ['admin'])
+export class AdminHealthCareCostController extends Controller {
+  @Get()
+  public async get(@Query() _id: string) {
+    return { data: await getCurrentReport('HealthCareCost', _id) }
+  }
+
+  @Get('report')
+  @Produces('application/pdf')
+  public async getReport(@Query() _id: string, @Request() request: AuthenticatedExpressRequest) {
+    return await getCurrentReportPdf(this, 'HealthCareCost', _id, request.user.settings.language)
+  }
+}
+
+@Tags('Admin', 'Advance')
+@Route('admin/advance')
+@Security('cookieAuth', ['admin'])
+@Security('httpBearer', ['admin'])
+export class AdminAdvanceController extends Controller {
+  @Get()
+  public async get(@Query() _id: string) {
+    return { data: await getCurrentReport('Advance', _id) }
+  }
+
+  @Get('report')
+  @Produces('application/pdf')
+  public async getReport(@Query() _id: string, @Request() request: AuthenticatedExpressRequest) {
+    return await getCurrentReportPdf(this, 'Advance', _id, request.user.settings.language)
+  }
+}

--- a/backend/controller/documentFileController.ts
+++ b/backend/controller/documentFileController.ts
@@ -62,3 +62,25 @@ export class DocumentFileAdminController extends Controller {
     return await this.deleter(DocumentFile, { _id: _id })
   }
 }
+
+@Tags('Admin', 'Document File')
+@Route('admin/documentFile')
+@Security('cookieAuth', ['admin'])
+@Security('httpBearer', ['admin'])
+export class AdminDocumentFileController extends Controller {
+  @Get()
+  @Produces(documentFileTypes[0])
+  @Produces(documentFileTypes[1])
+  @Produces(documentFileTypes[2])
+  @SuccessResponse(200)
+  public async getAny(@Query() _id: string) {
+    const file = await DocumentFile.findOne({ _id }).lean()
+    if (!file) {
+      throw new NotFoundError('No file found')
+    }
+    this.setHeader('Content-disposition', `inline; filename*=UTF-8''${encodeURIComponent(file.name)}`)
+    this.setHeader('Content-Type', file.type)
+    this.setHeader('Content-Length', file.data.length().toString())
+    return Readable.from([file.data.value()])
+  }
+}

--- a/backend/controller/searchController.ts
+++ b/backend/controller/searchController.ts
@@ -65,6 +65,11 @@ function getPermissionFilter(user: User) {
     return { historic: false, $or: [{ owner: user._id }, ...ors] }
   }
 
+  if (user.access.admin) {
+    const currentReports = { historic: false }
+    return { Travel: currentReports, ExpenseReport: currentReports, HealthCareCost: currentReports, Advance: currentReports }
+  }
+
   const travelStates = new Set<number>()
   if (user.access['approve/travel']) {
     travelStates.add(TravelState.APPLIED_FOR)

--- a/backend/tests/api/adminReports.ts
+++ b/backend/tests/api/adminReports.ts
@@ -32,6 +32,7 @@ const reportFixtures: {
 ]
 const reportIds = reportFixtures.map(() => new Types.ObjectId())
 const historicalTravelId = new Types.ObjectId()
+const foreignExpenseReportExchangeRateDate = new Date('2026-01-15T00:00:00.000Z')
 
 for (const [index, fixture] of reportFixtures.entries()) {
   await fixture.model.collection.insertOne({
@@ -42,7 +43,10 @@ for (const [index, fixture] of reportFixtures.entries()) {
     editor: owner._id,
     project: project._id,
     state: fixture.state,
-    historic: false
+    historic: false,
+    ...(fixture.type === 'ExpenseReport'
+      ? { currency: 'USD', exchangeRateDate: foreignExpenseReportExchangeRateDate, exchangeRate: 1.2 }
+      : {})
   })
 }
 
@@ -106,6 +110,11 @@ test.serial('admin can read current report details for every report type', async
     t.is(response.body.data._id, reportIds[index].toString(), endpoint)
     t.is(response.body.data.owner._id, owner._id.toString(), `${endpoint} owner`)
     t.is(response.body.data.project._id, project._id.toString(), `${endpoint} project`)
+    if (fixture.type === 'ExpenseReport') {
+      t.is(response.body.data.currency._id, 'USD', `${endpoint} currency`)
+      t.is(response.body.data.exchangeRateDate, foreignExpenseReportExchangeRateDate.toISOString(), `${endpoint} exchange rate date`)
+      t.is(response.body.data.exchangeRate, 1.2, `${endpoint} exchange rate`)
+    }
   }
 })
 

--- a/backend/tests/api/adminReports.ts
+++ b/backend/tests/api/adminReports.ts
@@ -1,0 +1,132 @@
+import { AdvanceState, ExpenseReportState, HealthCareCostState, ReportModelName, TravelState } from 'abrechnung-common/types.js'
+import test from 'ava'
+import { mongo, Types } from 'mongoose'
+import { shutdown } from '../../app.js'
+import Advance from '../../models/advance.js'
+import DocumentFile from '../../models/documentFile.js'
+import ExpenseReport from '../../models/expenseReport.js'
+import HealthCareCost from '../../models/healthCareCost.js'
+import Project from '../../models/project.js'
+import Travel from '../../models/travel.js'
+import User from '../../models/user.js'
+import createAgent, { loginUser } from '../_agent.js'
+
+const agent = await createAgent()
+const owner = await User.findOne({ 'fk.ldapauth': 'leela' })
+const project = await Project.findOne()
+
+if (!owner || !project) {
+  throw new Error('Admin report tests require a user and project fixture')
+}
+
+const searchTerm = 'adminvisibilityprobe'
+const reportFixtures: {
+  model: typeof Travel | typeof ExpenseReport | typeof HealthCareCost | typeof Advance
+  type: ReportModelName
+  state: number
+}[] = [
+  { model: Travel, type: 'Travel', state: TravelState.APPLIED_FOR },
+  { model: ExpenseReport, type: 'ExpenseReport', state: ExpenseReportState.IN_WORK },
+  { model: HealthCareCost, type: 'HealthCareCost', state: HealthCareCostState.BOOKED },
+  { model: Advance, type: 'Advance', state: AdvanceState.APPROVED }
+]
+const reportIds = reportFixtures.map(() => new Types.ObjectId())
+const historicalTravelId = new Types.ObjectId()
+
+for (const [index, fixture] of reportFixtures.entries()) {
+  await fixture.model.collection.insertOne({
+    _id: reportIds[index],
+    name: `${searchTerm} ${fixture.type}`,
+    reference: 9_900_000 + index,
+    owner: owner._id,
+    editor: owner._id,
+    project: project._id,
+    state: fixture.state,
+    historic: false
+  })
+}
+
+await Travel.collection.insertOne({
+  _id: historicalTravelId,
+  name: `${searchTerm} historical`,
+  reference: 9_900_100,
+  owner: owner._id,
+  editor: owner._id,
+  project: project._id,
+  state: TravelState.APPLIED_FOR,
+  historic: true
+})
+
+const documentFileId = new Types.ObjectId()
+await DocumentFile.collection.insertOne({
+  _id: documentFileId,
+  name: 'admin-report-receipt.pdf',
+  type: 'application/pdf',
+  data: new mongo.Binary(Buffer.from('receipt')),
+  owner: owner._id
+})
+
+test.serial('admin search includes every current report without workflow permissions', async (t) => {
+  await loginUser(agent, 'admin')
+  const response = await agent.get('/search').query({ term: searchTerm, limit: 50 })
+
+  t.is(response.status, 200)
+  t.is(response.body.meta.count, reportFixtures.length)
+  t.deepEqual(
+    new Set(response.body.data.map((report: { _reportModelName: ReportModelName }) => report._reportModelName)),
+    new Set(reportFixtures.map(({ type }) => type))
+  )
+})
+
+test.serial('admin reference lookup includes foreign reports regardless of status', async (t) => {
+  await loginUser(agent, 'admin')
+  const response = await agent.get('/search/ref').query({ ref: 9_900_000, type: 'Travel' })
+
+  t.is(response.status, 200)
+  t.is(response.body.data._id, reportIds[0].toString())
+})
+
+test.serial('non-admin search permissions remain unchanged', async (t) => {
+  await loginUser(agent, 'user')
+  const searchResponse = await agent.get('/search').query({ term: searchTerm, limit: 50 })
+  const referenceResponse = await agent.get('/search/ref').query({ ref: 9_900_000, type: 'Travel' })
+
+  t.is(searchResponse.status, 200)
+  t.is(searchResponse.body.meta.count, 0)
+  t.is(referenceResponse.status, 404)
+})
+
+test.serial('admin can read current report details for every report type', async (t) => {
+  await loginUser(agent, 'admin')
+
+  for (const [index, fixture] of reportFixtures.entries()) {
+    const endpoint = `/admin/${fixture.type[0].toLowerCase()}${fixture.type.slice(1)}`
+    const response = await agent.get(endpoint).query({ _id: reportIds[index].toString() })
+    t.is(response.status, 200, endpoint)
+    t.is(response.body.data._id, reportIds[index].toString(), endpoint)
+    t.is(response.body.data.owner._id, owner._id.toString(), `${endpoint} owner`)
+    t.is(response.body.data.project._id, project._id.toString(), `${endpoint} project`)
+  }
+})
+
+test.serial('admin read endpoints exclude historic reports and reject non-admins', async (t) => {
+  await loginUser(agent, 'admin')
+  const historicalResponse = await agent.get('/admin/travel').query({ _id: historicalTravelId.toString() })
+  const fileResponse = await agent.get('/admin/documentFile').query({ _id: documentFileId.toString() })
+
+  t.is(historicalResponse.status, 404)
+  t.is(fileResponse.status, 200)
+
+  await loginUser(agent, 'user')
+  t.is((await agent.get('/admin/travel').query({ _id: reportIds[0].toString() })).status, 401)
+  t.is((await agent.get('/admin/documentFile').query({ _id: documentFileId.toString() })).status, 401)
+})
+
+test.serial.after.always('clean up admin report fixtures', async () => {
+  await Promise.all([
+    ...reportFixtures.map((fixture, index) => fixture.model.collection.deleteOne({ _id: reportIds[index] })),
+    Travel.collection.deleteOne({ _id: historicalTravelId }),
+    DocumentFile.deleteOne({ _id: documentFileId })
+  ])
+  await shutdown()
+})

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -121,11 +121,11 @@
   </div>
   <div class="position-relative">
     <AlertComponent />
-    <router-view :class="loadState === 'LOADED' ? 'd-block' : 'd-none'" v-slot="{ Component }">
+    <router-view :class="loadState === 'LOADED' ? 'd-block' : 'd-none'" v-slot="{ Component, route }">
       <template v-if="Component">
         <Suspense>
           <template #default>
-            <component :is="Component"></component>
+            <component :is="Component" :key="route.meta.remountOnPathChange ? route.path : undefined"></component>
           </template>
           <template #fallback></template>
         </Suspense>

--- a/frontend/src/components/advance/AdminPage.vue
+++ b/frontend/src/components/advance/AdminPage.vue
@@ -1,0 +1,28 @@
+<template>
+  <div v-if="advance" class="container py-3">
+    <div class="d-flex align-items-center mb-3">
+      <h2 class="m-0">{{ advance.name }}</h2>
+      <RefStringBadge class="ms-2" :number="advance.reference" type="Advance" />
+    </div>
+    <Advance :advance="advance" endpoint-prefix="admin/" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { AdvanceSimple } from 'abrechnung-common/types.js'
+import { ref, watch } from 'vue'
+import API from '@/api.js'
+import Advance from '@/components/advance/Advance.vue'
+import RefStringBadge from '@/components/elements/RefStringBadge.vue'
+
+const props = defineProps<{ _id: string }>()
+const advance = ref<AdvanceSimple<string>>()
+
+async function loadAdvance() {
+  const result = (await API.getter<AdvanceSimple<string>>('admin/advance', { _id: props._id })).ok
+  advance.value = result?.data
+}
+
+await loadAdvance()
+watch(() => props._id, loadAdvance)
+</script>

--- a/frontend/src/components/expenseReport/ExpenseReportPage.vue
+++ b/frontend/src/components/expenseReport/ExpenseReportPage.vue
@@ -18,7 +18,7 @@
           :default-project="expenseReport.project"
           :report-currency="expenseReport.currency || undefined"
           :endpointPrefix="endpointPrefix"
-          :ownerId="endpointPrefix === 'examine/' ? expenseReport.owner._id : undefined"
+          :ownerId="endpointPrefix === 'examine/' || viewOnly ? expenseReport.owner._id : undefined"
           :show-next-button="modalMode === 'edit' && Boolean(getNext(modalObject as Expense<string>))"
           :show-prev-button="modalMode === 'edit' && Boolean(getPrev(modalObject as Expense<string>))"
           @add="postExpense"
@@ -33,7 +33,7 @@
           :expenseReport="(modalObject as Partial<ExpenseReportSimple<string>>)"
           :loading="modalFormIsLoading"
           :owner="expenseReport.owner"
-          :update-user-org="endpointPrefix !== 'examine/'"
+          :update-user-org="endpointPrefix !== 'examine/' && !viewOnly"
           :endpoint-prefix="endpointPrefix"
           @cancel="resetAndHide()"
           @edit="editExpenseReportDetails" />
@@ -99,7 +99,7 @@
                 <li>
                   <a
                     :class="'dropdown-item clickable' + (isReadOnly ? ' disabled' : '')"
-                    @click="showModal('edit', 'expenseReport', expenseReport)">
+                    @click="viewOnly ? null : showModal('edit', 'expenseReport', expenseReport)">
                     <span class="me-1"><i class="bi bi-pencil"></i></span>
                     <span>{{ t('labels.editX', { X: t('labels.XDetails', { X: t('labels.expenseReport') }) }) }}</span>
                   </a>
@@ -107,11 +107,15 @@
                 <li><a
                   :class="
                       'dropdown-item clickable' +
-                      (isReadOnly && endpointPrefix === 'examine/' && expenseReport.state < State.BOOKABLE ? ' disabled' : '')
+                      (viewOnly || (isReadOnly && endpointPrefix === 'examine/' && expenseReport.state < State.BOOKABLE)
+                        ? ' disabled'
+                        : '')
                     "
                   @click="
-                      isReadOnly && endpointPrefix === 'examine/' && expenseReport.state < State.BOOKABLE ? null : deleteExpenseReport()
-                    ">
+                    viewOnly || (isReadOnly && endpointPrefix === 'examine/' && expenseReport.state < State.BOOKABLE)
+                      ? null
+                      : deleteExpenseReport()
+                  ">
                   <span class="me-1"><i class="bi bi-trash"></i></span>
                   <span>{{ t('labels.delete') }}</span>
                 </a></li>
@@ -120,7 +124,7 @@
           </div>
         </div>
         <div class="text-secondary">
-          {{ (endpointPrefix === 'examine/' ? formatter.name(expenseReport.owner.name) + ' - ' : '') +
+          {{ (endpointPrefix === 'examine/' || viewOnly ? formatter.name(expenseReport.owner.name) + ' - ' : '') +
             expenseReport.project.identifier +
             (expenseReport.project.name ? ' ' + expenseReport.project.name : '') }}
         </div>
@@ -287,8 +291,12 @@
                   <div>
                     <button
                       class="btn btn-secondary"
-                      @click="expenseReport.editor._id !== expenseReport.owner._id && endpointPrefix !== 'examine/' ? null : backToInWork()"
-                      :disabled="expenseReport.editor._id !== expenseReport.owner._id && endpointPrefix !== 'examine/'">
+                      @click="
+                        viewOnly || (expenseReport.editor._id !== expenseReport.owner._id && endpointPrefix !== 'examine/')
+                          ? null
+                          : backToInWork()
+                      "
+                      :disabled="viewOnly || (expenseReport.editor._id !== expenseReport.owner._id && endpointPrefix !== 'examine/')">
                       <i class="bi bi-arrow-counterclockwise"></i>
                       <span class="ms-1">{{ t(endpointPrefix === 'examine/' ? 'labels.backToApplicant' : 'labels.editAgain') }}</span>
                     </button>
@@ -363,7 +371,8 @@ const expenseReportCompletionValidator = new Validator({ requireExchangeRate: tr
 const props = defineProps({
   _id: { type: String, required: true },
   parentPages: { type: Array as PropType<{ link: string; title: string }[]>, required: true },
-  endpointPrefix: { type: String, default: '' }
+  endpointPrefix: { type: String, default: '' },
+  viewOnly: { type: Boolean, default: false }
 })
 
 const router = useRouter()
@@ -384,6 +393,7 @@ const modalFormIsLoading = ref(false)
 
 const isReadOnly = computed(() => {
   return (
+    props.viewOnly ||
     !sessionState.isOnline.value ||
     ((expenseReport.value.state > State.EDITABLE_BY_OWNER ||
       (expenseReport.value.state === State.EDITABLE_BY_OWNER && props.endpointPrefix === 'examine/')) &&

--- a/frontend/src/components/healthCareCost/HealthCareCostPage.vue
+++ b/frontend/src/components/healthCareCost/HealthCareCostPage.vue
@@ -17,7 +17,7 @@
           :mode="modalMode"
           :default-project="healthCareCost.project"
           :endpointPrefix="endpointPrefix"
-          :ownerId="endpointPrefix === 'examine/' ? healthCareCost.owner._id : undefined"
+          :ownerId="endpointPrefix === 'examine/' || viewOnly ? healthCareCost.owner._id : undefined"
           :show-next-button="modalMode === 'edit' && Boolean(getNext(modalObject as Expense<string>))"
           :show-prev-button="modalMode === 'edit' && Boolean(getPrev(modalObject as Expense<string>))"
           @add="postExpense"
@@ -32,7 +32,7 @@
           :healthCareCost="modalObject as HealthCareCostSimple<string>"
           :loading="modalFormIsLoading"
           :owner="healthCareCost.owner"
-          :update-user-org="endpointPrefix !== 'examine/'"
+          :update-user-org="endpointPrefix !== 'examine/' && !viewOnly"
           :endpoint-prefix="endpointPrefix"
           @cancel="resetAndHide()"
           @edit="editHealthCareCostDetails" />
@@ -98,16 +98,17 @@
                 <li>
                   <a
                     :class="'dropdown-item clickable' + (isReadOnly ? ' disabled' : '')"
-                    @click="showModal('edit', 'healthCareCost', healthCareCost)">
+                    @click="viewOnly ? null : showModal('edit', 'healthCareCost', healthCareCost)">
                     <span class="me-1"><i class="bi bi-pencil"></i></span>
                     <span>{{ t('labels.editX', { X: t('labels.XDetails', { X: t('labels.healthCareCost') }) }) }}</span>
                   </a>
                 </li>
                 <li><a
                   :class="
-                      'dropdown-item clickable' + (isReadOnly && endpointPrefix !== '' && healthCareCost.state < State.BOOKABLE ? ' disabled' : '')
+                      'dropdown-item clickable' +
+                      (viewOnly || (isReadOnly && endpointPrefix !== '' && healthCareCost.state < State.BOOKABLE) ? ' disabled' : '')
                     "
-                  @click="isReadOnly && endpointPrefix !== '' && healthCareCost.state < State.BOOKABLE ? null : deleteHealthCareCost()">
+                  @click="viewOnly || (isReadOnly && endpointPrefix !== '' && healthCareCost.state < State.BOOKABLE) ? null : deleteHealthCareCost()">
                   <span class="me-1"><i class="bi bi-trash"></i></span>
                   <span>{{ t('labels.delete') }}</span>
                 </a></li>
@@ -116,7 +117,7 @@
           </div>
         </div>
         <div class="text-secondary">
-          {{ (endpointPrefix === 'examine/' ? formatter.name(healthCareCost.owner.name) + ' - ' : '') +
+          {{ (endpointPrefix === 'examine/' || viewOnly ? formatter.name(healthCareCost.owner.name) + ' - ' : '') +
             healthCareCost.project.identifier +
             (healthCareCost.project.name ? ' ' + healthCareCost.project.name : '') }}
         </div>
@@ -234,9 +235,11 @@
                     <button
                       class="btn btn-secondary"
                       @click="
-                        healthCareCost.editor._id !== healthCareCost.owner._id && endpointPrefix !== 'examine/' ? null : backToInWork()
+                        viewOnly || (healthCareCost.editor._id !== healthCareCost.owner._id && endpointPrefix !== 'examine/')
+                          ? null
+                          : backToInWork()
                       "
-                      :disabled="healthCareCost.editor._id !== healthCareCost.owner._id && endpointPrefix !== 'examine/'">
+                      :disabled="viewOnly || (healthCareCost.editor._id !== healthCareCost.owner._id && endpointPrefix !== 'examine/')">
                       <i class="bi bi-arrow-counterclockwise"></i>
                       <span class="ms-1">{{ t(endpointPrefix === 'examine/' ? 'labels.backToApplicant' : 'labels.editAgain') }}</span>
                     </button>
@@ -324,7 +327,8 @@ const healthCareCostValidator = new Validator({ requireReceipts: true })
 const props = defineProps({
   _id: { type: String, required: true },
   parentPages: { type: Array as PropType<{ link: string; title: string }[]>, required: true },
-  endpointPrefix: { type: String, default: '' }
+  endpointPrefix: { type: String, default: '' },
+  viewOnly: { type: Boolean, default: false }
 })
 
 const router = useRouter()
@@ -344,6 +348,7 @@ const isDownloadingFn = () => isDownloading
 
 const isReadOnly = computed(() => {
   return (
+    props.viewOnly ||
     !sessionState.isOnline.value ||
     ((healthCareCost.value.state > State.EDITABLE_BY_OWNER ||
       (healthCareCost.value.state === State.EDITABLE_BY_OWNER && props.endpointPrefix === 'examine/')) &&

--- a/frontend/src/components/travel/TravelPage.vue
+++ b/frontend/src/components/travel/TravelPage.vue
@@ -22,11 +22,11 @@
           :disabled="isReadOnly"
           :loading="modalFormIsLoading"
           :vehicleRegistration="
-            endpointPrefix !== 'examine/' && travel.state === TravelState.APPROVED ? APP_DATA.user.vehicleRegistration : null
+            !viewOnly && endpointPrefix !== 'examine/' && travel.state === TravelState.APPROVED ? APP_DATA.user.vehicleRegistration : null
           "
           :travelSettings="APP_DATA.travelSettings"
           :endpointPrefix="endpointPrefix"
-          :ownerId="endpointPrefix === 'examine/' ? travel.owner._id : undefined"
+          :ownerId="endpointPrefix === 'examine/' || viewOnly ? travel.owner._id : undefined"
           :show-next-button="modalMode === 'edit' && Boolean(tableRef?.getNext((modalObject as Stage), modalObjectType))"
           :show-prev-button="modalMode === 'edit' && Boolean(tableRef?.getPrev((modalObject as Stage), modalObjectType))"
           @add="postStage"
@@ -44,7 +44,7 @@
           :mode="modalMode"
           :default-project="travel.project"
           :endpointPrefix="endpointPrefix"
-          :ownerId="endpointPrefix === 'examine/' ? travel.owner._id : undefined"
+          :ownerId="endpointPrefix === 'examine/' || viewOnly ? travel.owner._id : undefined"
           :show-next-button="modalMode === 'edit' && Boolean(tableRef?.getNext((modalObject as TravelExpense), modalObjectType))"
           :show-prev-button="modalMode === 'edit' && Boolean(tableRef?.getPrev((modalObject as TravelExpense), modalObjectType))"
           @add="postExpense"
@@ -61,7 +61,7 @@
           :createNotApply="APP_DATA?.user.access['approved:travel']"
           :loading="modalFormIsLoading"
           :owner="travel.owner"
-          :update-user-org="endpointPrefix !== 'examine/'"
+          :update-user-org="endpointPrefix !== 'examine/' && !viewOnly"
           :endpoint-prefix="endpointPrefix"
           @cancel="resetAndHide"
           @edit="(t) =>editTravelDetails(t as TravelSimple<string>)" />
@@ -142,15 +142,18 @@
                 <li>
                   <hr class="dropdown-divider" >
                 </li>
-                <li><a :class="'dropdown-item clickable' + (isReadOnly ? ' disabled' : '')" @click="showModal('edit', 'travel', travel)">
+                <li><a
+                  :class="'dropdown-item clickable' + (isReadOnly ? ' disabled' : '')"
+                  @click="viewOnly ? null : showModal('edit', 'travel', travel)">
                   <span class="me-1"><i class="bi bi-pencil"></i></span>
                   <span>{{ t('labels.editX', { X: t('labels.XDetails', { X: t('labels.travel') }) }) }}</span>
                 </a></li>
                 <li><a
                   :class="
-                      'dropdown-item clickable' + (isReadOnly && endpointPrefix === 'examine/' && travel.state < State.BOOKABLE ? ' disabled' : '')
+                      'dropdown-item clickable' +
+                      (viewOnly || (isReadOnly && endpointPrefix === 'examine/' && travel.state < State.BOOKABLE) ? ' disabled' : '')
                     "
-                  @click="isReadOnly && endpointPrefix === 'examine/' && travel.state < State.BOOKABLE ? null : deleteTravel()">
+                  @click="viewOnly || (isReadOnly && endpointPrefix === 'examine/' && travel.state < State.BOOKABLE) ? null : deleteTravel()">
                   <span class="me-1"><i class="bi bi-trash"></i></span>
                   <span>{{ t('labels.delete') }}</span>
                 </a></li>
@@ -159,7 +162,7 @@
           </div>
         </div>
         <div class="text-secondary">
-          {{ (endpointPrefix === 'examine/' ? formatter.name(travel.owner.name) + ' - ' : '') +
+          {{ (endpointPrefix === 'examine/' || viewOnly ? formatter.name(travel.owner.name) + ' - ' : '') +
             travel.project.identifier +
             (travel.project.name ? ' ' + travel.project.name : '') }}
         </div>
@@ -200,8 +203,8 @@
             <div class="col-auto">
               <button
                 class="btn btn-outline-secondary"
-                @click="travel.days.length < 1 ? null : showModal('edit', 'lumpSums', undefined)"
-                :disabled="travel.days.length < 1">
+                @click="viewOnly || travel.days.length < 1 ? null : showModal('edit', 'lumpSums', undefined)"
+                :disabled="viewOnly || travel.days.length < 1">
                 <span class="ms-1 d-none d-md-inline">{{ t('labels.editX', { X: t('labels.lumpSums') }) }}</span>
                 <span class="ms-1 d-md-none">{{ t('labels.lumpSums') }}</span>
               </button>
@@ -283,8 +286,8 @@
                     <div>
                       <button
                         class="btn btn-secondary"
-                        @click="travel.editor._id !== travel.owner._id && endpointPrefix !== 'examine/' ? null : backToApproved()"
-                        :disabled="travel.editor._id !== travel.owner._id && endpointPrefix !== 'examine/'">
+                        @click="viewOnly || (travel.editor._id !== travel.owner._id && endpointPrefix !== 'examine/') ? null : backToApproved()"
+                        :disabled="viewOnly || (travel.editor._id !== travel.owner._id && endpointPrefix !== 'examine/')">
                         <i class="bi bi-arrow-counterclockwise"></i>
                         <span class="ms-1">{{ t(endpointPrefix === 'examine/' ? 'labels.backToApplicant' : 'labels.editAgain') }}</span>
                       </button>
@@ -377,7 +380,8 @@ type ModalObjectType = TravelRecordType | 'travel' | 'lumpSums' | 'stageImport'
 const props = defineProps({
   _id: { type: String, required: true },
   parentPages: { type: Array as PropType<{ link: string; title: string }[]>, required: true },
-  endpointPrefix: { type: String, default: '' }
+  endpointPrefix: { type: String, default: '' },
+  viewOnly: { type: Boolean, default: false }
 })
 
 const router = useRouter()
@@ -405,6 +409,7 @@ const APP_DATA = APP_LOADER.data
 
 const isReadOnly = computed(() => {
   return (
+    props.viewOnly ||
     !sessionState.isOnline.value ||
     ((travel.value.state > State.EDITABLE_BY_OWNER ||
       (travel.value.state === State.EDITABLE_BY_OWNER && props.endpointPrefix === 'examine/')) &&
@@ -422,10 +427,10 @@ const travelValidationResults = computed(() => {
     return [] as ValidationResult[]
   }
   const results = APP_DATA.value.travelCalculator.validator.getValidationSummary(travel.value, {
-    vehicleRegistration: props.endpointPrefix !== 'examine/' ? APP_DATA.value.user.vehicleRegistration : null
+    vehicleRegistration: props.endpointPrefix !== 'examine/' && !props.viewOnly ? APP_DATA.value.user.vehicleRegistration : null
   }).results
 
-  if (props.endpointPrefix !== 'examine/') {
+  if (props.endpointPrefix !== 'examine/' && !props.viewOnly) {
     return results
   }
 

--- a/frontend/src/helper.ts
+++ b/frontend/src/helper.ts
@@ -135,14 +135,14 @@ export function getRouteForReport(
   }
 
   if (reportType === 'advance') {
-    if (user.access['approve/advance']) {
+    if (user.access['approve/advance'] && report.state >= State.APPLIED_FOR) {
       return `/approve/advance/${report._id}`
-    }
-    if (user.access['book/advance']) {
-      return `/book/advance/${report._id}`
     }
     if (user.access.admin) {
       return `/admin/report/${reportType}/${report._id}`
+    }
+    if (user.access['book/advance']) {
+      return `/book/advance/${report._id}`
     }
     return `/book/advance/${report._id}`
   }
@@ -151,14 +151,14 @@ export function getRouteForReport(
     if (user.access['examine/travel'] && report.state >= TravelState.APPROVED && report.state <= TravelState.REVIEW_COMPLETED) {
       return `/examine/travel/${report._id}`
     }
-    if (user.access['approve/travel'] && report.state <= TravelState.APPROVED) {
+    if (user.access['approve/travel'] && report.state >= TravelState.APPLIED_FOR && report.state <= TravelState.APPROVED) {
       return `/approve/travel/${report._id}`
-    }
-    if (user.access['book/travel']) {
-      return `/book/travel/${report._id}`
     }
     if (user.access.admin) {
       return `/admin/report/${reportType}/${report._id}`
+    }
+    if (user.access['book/travel']) {
+      return `/book/travel/${report._id}`
     }
     return `/book/travel/${report._id}`
   }
@@ -167,11 +167,11 @@ export function getRouteForReport(
   if (user.access[`examine/${reportType}`] && report.state >= State.EDITABLE_BY_OWNER && report.state <= State.BOOKABLE) {
     return `/examine/${reportType}/${report._id}`
   }
-  if (user.access[`book/${reportType}`]) {
-    return `/book/${reportType}/${report._id}`
-  }
   if (user.access.admin) {
     return `/admin/report/${reportType}/${report._id}`
+  }
+  if (user.access[`book/${reportType}`]) {
+    return `/book/${reportType}/${report._id}`
   }
   return `/book/${reportType}/${report._id}`
 }

--- a/frontend/src/helper.ts
+++ b/frontend/src/helper.ts
@@ -138,6 +138,12 @@ export function getRouteForReport(
     if (user.access['approve/advance']) {
       return `/approve/advance/${report._id}`
     }
+    if (user.access['book/advance']) {
+      return `/book/advance/${report._id}`
+    }
+    if (user.access.admin) {
+      return `/admin/report/${reportType}/${report._id}`
+    }
     return `/book/advance/${report._id}`
   }
 
@@ -148,12 +154,24 @@ export function getRouteForReport(
     if (user.access['approve/travel'] && report.state <= TravelState.APPROVED) {
       return `/approve/travel/${report._id}`
     }
+    if (user.access['book/travel']) {
+      return `/book/travel/${report._id}`
+    }
+    if (user.access.admin) {
+      return `/admin/report/${reportType}/${report._id}`
+    }
     return `/book/travel/${report._id}`
   }
 
   //reportType === 'expenseReport' || reportType === 'healthCareCost'
   if (user.access[`examine/${reportType}`] && report.state >= State.EDITABLE_BY_OWNER && report.state <= State.BOOKABLE) {
     return `/examine/${reportType}/${report._id}`
+  }
+  if (user.access[`book/${reportType}`]) {
+    return `/book/${reportType}/${report._id}`
+  }
+  if (user.access.admin) {
+    return `/admin/report/${reportType}/${report._id}`
   }
   return `/book/${reportType}/${report._id}`
 }

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -17,6 +17,30 @@ const routes = [
   },
   { path: '/offline-unavailable', component: () => import('@/components/OfflineUnavailablePage.vue'), meta: { requiresAuth: false } },
   {
+    path: '/admin/report/travel/:_id([0-9a-fA-F]{24})',
+    component: () => import('@/components/travel/TravelPage.vue'),
+    meta: { requiresAuth: true, requiredAccess: 'admin' },
+    props: (route: RouteLocationNormalized) => ({ _id: route.params._id, parentPages: [], endpointPrefix: 'admin/', viewOnly: true })
+  },
+  {
+    path: '/admin/report/expenseReport/:_id([0-9a-fA-F]{24})',
+    component: () => import('@/components/expenseReport/ExpenseReportPage.vue'),
+    meta: { requiresAuth: true, requiredAccess: 'admin' },
+    props: (route: RouteLocationNormalized) => ({ _id: route.params._id, parentPages: [], endpointPrefix: 'admin/', viewOnly: true })
+  },
+  {
+    path: '/admin/report/healthCareCost/:_id([0-9a-fA-F]{24})',
+    component: () => import('@/components/healthCareCost/HealthCareCostPage.vue'),
+    meta: { requiresAuth: true, requiredAccess: 'admin' },
+    props: (route: RouteLocationNormalized) => ({ _id: route.params._id, parentPages: [], endpointPrefix: 'admin/', viewOnly: true })
+  },
+  {
+    path: '/admin/report/advance/:_id([0-9a-fA-F]{24})',
+    component: () => import('@/components/advance/AdminPage.vue'),
+    meta: { requiresAuth: true, requiredAccess: 'admin' },
+    props: (route: RouteLocationNormalized) => ({ _id: route.params._id })
+  },
+  {
     path: '/admin',
     component: () => import('@/components/settings/SettingsPage.vue'),
     meta: { requiresAuth: true, requiresVueform: true },

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -19,19 +19,19 @@ const routes = [
   {
     path: '/admin/report/travel/:_id([0-9a-fA-F]{24})',
     component: () => import('@/components/travel/TravelPage.vue'),
-    meta: { requiresAuth: true, requiredAccess: 'admin' },
+    meta: { requiresAuth: true, requiredAccess: 'admin', remountOnPathChange: true },
     props: (route: RouteLocationNormalized) => ({ _id: route.params._id, parentPages: [], endpointPrefix: 'admin/', viewOnly: true })
   },
   {
     path: '/admin/report/expenseReport/:_id([0-9a-fA-F]{24})',
     component: () => import('@/components/expenseReport/ExpenseReportPage.vue'),
-    meta: { requiresAuth: true, requiredAccess: 'admin' },
+    meta: { requiresAuth: true, requiredAccess: 'admin', remountOnPathChange: true },
     props: (route: RouteLocationNormalized) => ({ _id: route.params._id, parentPages: [], endpointPrefix: 'admin/', viewOnly: true })
   },
   {
     path: '/admin/report/healthCareCost/:_id([0-9a-fA-F]{24})',
     component: () => import('@/components/healthCareCost/HealthCareCostPage.vue'),
-    meta: { requiresAuth: true, requiredAccess: 'admin' },
+    meta: { requiresAuth: true, requiredAccess: 'admin', remountOnPathChange: true },
     props: (route: RouteLocationNormalized) => ({ _id: route.params._id, parentPages: [], endpointPrefix: 'admin/', viewOnly: true })
   },
   {

--- a/frontend/tests/reportLinks.test.ts
+++ b/frontend/tests/reportLinks.test.ts
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 vi.mock('@/api.js', () => ({ default: { getter: vi.fn() } }))
 
 import API from '@/api.js'
-import { getReportReferenceUrl, getRouteForReportReference } from '@/helper.js'
+import { getReportReferenceUrl, getRouteForReport, getRouteForReportReference } from '@/helper.js'
 
 const owner = { _id: 'owner' } as User
 const meta = { count: 1, page: 1, limit: 1, countPages: 1 }
@@ -34,6 +34,35 @@ describe('report reference links', () => {
     } as never)
 
     await expect(getRouteForReportReference(examiner, 'T-001')).resolves.toBe('/examine/travel/report-id')
+  })
+
+  it.each([
+    ['Travel', '/admin/report/travel/report-id'],
+    ['ExpenseReport', '/admin/report/expenseReport/report-id'],
+    ['HealthCareCost', '/admin/report/healthCareCost/report-id'],
+    ['Advance', '/admin/report/advance/report-id']
+  ] as [ReportModelName, string][])(
+    'routes an admin without report permissions to the read-only %s view',
+    (reportModelName, expectedRoute) => {
+      const admin = { _id: 'admin', access: { admin: true } } as unknown as User
+      const report = { _id: 'report-id', owner: 'owner', state: TravelState.APPLIED_FOR }
+
+      expect(getRouteForReport(admin, report, reportModelName)).toBe(expectedRoute)
+    }
+  )
+
+  it('keeps owner access ahead of the additional admin read access', () => {
+    const adminOwner = { _id: 'owner', access: { admin: true } } as unknown as User
+    const report = { _id: 'report-id', owner: 'owner', state: TravelState.APPLIED_FOR }
+
+    expect(getRouteForReport(adminOwner, report, 'Travel')).toBe('/travel/report-id')
+  })
+
+  it('keeps explicit workflow access ahead of the additional admin read access', () => {
+    const adminExaminer = { _id: 'admin', access: { admin: true, 'examine/travel': true } } as unknown as User
+    const report = { _id: 'report-id', owner: 'owner', state: TravelState.APPROVED }
+
+    expect(getRouteForReport(adminExaminer, report, 'Travel')).toBe('/examine/travel/report-id')
   })
 
   it('does not request malformed references', async () => {

--- a/frontend/tests/reportLinks.test.ts
+++ b/frontend/tests/reportLinks.test.ts
@@ -1,4 +1,4 @@
-import { type ReportModelName, TravelState, type User } from 'abrechnung-common/types.js'
+import { AdvanceState, type ReportModelName, State, TravelState, type User } from 'abrechnung-common/types.js'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/api.js', () => ({ default: { getter: vi.fn() } }))
@@ -58,11 +58,51 @@ describe('report reference links', () => {
     expect(getRouteForReport(adminOwner, report, 'Travel')).toBe('/travel/report-id')
   })
 
-  it('keeps explicit workflow access ahead of the additional admin read access', () => {
-    const adminExaminer = { _id: 'admin', access: { admin: true, 'examine/travel': true } } as unknown as User
-    const report = { _id: 'report-id', owner: 'owner', state: TravelState.APPROVED }
+  it.each([
+    ['Travel', TravelState.APPROVED, { 'examine/travel': true }, '/examine/travel/report-id'],
+    ['Travel', TravelState.APPLIED_FOR, { 'approve/travel': true }, '/approve/travel/report-id'],
+    ['ExpenseReport', State.EDITABLE_BY_OWNER, { 'examine/expenseReport': true }, '/examine/expenseReport/report-id'],
+    ['HealthCareCost', State.EDITABLE_BY_OWNER, { 'examine/healthCareCost': true }, '/examine/healthCareCost/report-id'],
+    ['Advance', AdvanceState.APPLIED_FOR, { 'approve/advance': true }, '/approve/advance/report-id']
+  ] as const)('keeps explicit workflow access ahead of the admin view for %s', (reportModelName, state, workflowAccess, expectedRoute) => {
+    const admin = { _id: 'admin', access: { admin: true, ...workflowAccess } } as unknown as User
+    const report = { _id: 'report-id', owner: 'owner', state }
 
-    expect(getRouteForReport(adminExaminer, report, 'Travel')).toBe('/examine/travel/report-id')
+    expect(getRouteForReport(admin, report, reportModelName)).toBe(expectedRoute)
+  })
+
+  it.each([
+    ['Travel', TravelState.REJECTED, { 'approve/travel': true }, '/admin/report/travel/report-id'],
+    ['Advance', AdvanceState.REJECTED, { 'approve/advance': true }, '/admin/report/advance/report-id']
+  ] as const)('routes a rejected %s to the admin view instead of approval', (reportModelName, state, workflowAccess, expectedRoute) => {
+    const admin = { _id: 'admin', access: { admin: true, ...workflowAccess } } as unknown as User
+    const report = { _id: 'report-id', owner: 'owner', state }
+
+    expect(getRouteForReport(admin, report, reportModelName)).toBe(expectedRoute)
+  })
+
+  it.each([
+    ['Travel', TravelState.REVIEW_COMPLETED, { 'book/travel': true }, '/admin/report/travel/report-id'],
+    ['ExpenseReport', State.BOOKABLE, { 'book/expenseReport': true }, '/admin/report/expenseReport/report-id'],
+    ['HealthCareCost', State.BOOKABLE, { 'book/healthCareCost': true }, '/admin/report/healthCareCost/report-id'],
+    ['Advance', AdvanceState.APPROVED, { 'book/advance': true }, '/admin/report/advance/report-id']
+  ] as const)('keeps the admin view ahead of booking for %s', (reportModelName, state, bookingAccess, expectedRoute) => {
+    const admin = { _id: 'admin', access: { admin: true, ...bookingAccess } } as unknown as User
+    const report = { _id: 'report-id', owner: 'owner', state }
+
+    expect(getRouteForReport(admin, report, reportModelName)).toBe(expectedRoute)
+  })
+
+  it.each([
+    ['Travel', TravelState.REVIEW_COMPLETED, { 'book/travel': true }, '/book/travel/report-id'],
+    ['ExpenseReport', State.BOOKABLE, { 'book/expenseReport': true }, '/book/expenseReport/report-id'],
+    ['HealthCareCost', State.BOOKABLE, { 'book/healthCareCost': true }, '/book/healthCareCost/report-id'],
+    ['Advance', AdvanceState.APPROVED, { 'book/advance': true }, '/book/advance/report-id']
+  ] as const)('keeps the booking route for a non-admin %s booker', (reportModelName, state, bookingAccess, expectedRoute) => {
+    const booker = { _id: 'booker', access: bookingAccess } as unknown as User
+    const report = { _id: 'report-id', owner: 'owner', state }
+
+    expect(getRouteForReport(booker, report, reportModelName)).toBe(expectedRoute)
   })
 
   it('does not request malformed references', async () => {


### PR DESCRIPTION
Ermöglicht Admins, alle aktuellen Abrechnungen über die Suche zu öffnen und schreibgeschützt anzusehen, einschließlich Belegen und – sofern verfügbar – PDF-Berichten. Ergänzt admin-geschützte APIs und Routen sowie Tests für Berechtigungen und Verlinkung.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added admin access to Travel, Expense, Health Care Cost, and Advance reports.
  - Added report detail views, downloadable PDF reports, and document downloads for administrators.
  - Added dedicated admin pages and navigation for all supported report types.
  - Added read-only viewing for reports, preventing unintended edits or deletions.

- **Improvements**
  - Enhanced report routing based on approval status and booking permissions.
  - Administrators can search and access all active reports, regardless of workflow restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->